### PR TITLE
Add itest for multi unit alerts

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -49,7 +49,7 @@ applications:
   {%- if testing %}
   avalanche:
     charm: {{ avalanche|default('avalanche-k8s', true) }}
-    scale: 1
+    scale: 2
     trust: true
     {%- if avalanche is defined and avalanche.endswith('.charm') %}
     resources:
@@ -57,6 +57,9 @@ applications:
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
+    options:
+      metric_count: 10
+      series_count: 2
   {%- endif %}
 
 relations:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -8,10 +8,12 @@ import urllib.request
 from pathlib import Path
 from typing import List
 
+from pytest_operator.plugin import OpsTest
+
 log = logging.getLogger(__name__)
 
 
-async def cli_deploy_bundle(ops_test, name: str, channel: str = "edge"):
+async def cli_deploy_bundle(ops_test: OpsTest, name: str, channel: str = "edge"):
     # use CLI to deploy bundle until https://github.com/juju/python-libjuju/issues/511 is fixed.
     run_args = [
         "juju",
@@ -30,13 +32,13 @@ async def cli_deploy_bundle(ops_test, name: str, channel: str = "edge"):
     await ops_test.model.wait_for_idle(timeout=1000)
 
 
-async def get_unit_address(ops_test, app_name: str, unit_num: int) -> str:
+async def get_unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
     # return ops_test.model.applications[app_name].units[unit_num].data["private-address"]
     status = await ops_test.model.get_status()  # noqa: F821
     return status["applications"][app_name]["units"][f"{app_name}/{unit_num}"]["address"]
 
 
-async def get_alertmanager_alerts(ops_test, unit_name, unit_num, retries=3) -> List[dict]:
+async def get_alertmanager_alerts(ops_test: OpsTest, unit_name, unit_num, retries=3) -> List[dict]:
     """Get a list of alerts.
 
     Response looks like this:
@@ -75,7 +77,7 @@ async def get_alertmanager_alerts(ops_test, unit_name, unit_num, retries=3) -> L
     return alerts
 
 
-async def get_alertmanager_groups(ops_test, unit_name, unit_num, retries=3) -> List[dict]:
+async def get_alertmanager_groups(ops_test: OpsTest, unit_name, unit_num, retries=3) -> List[dict]:
     """Get a list of groups of alerts.
 
     Response looks like this:

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -157,3 +157,14 @@ async def test_alerts_are_grouped(ops_test):
 
     assert i >= 0  # should have at least one group listed (the "AlwaysFiring" alarm rule)
     log.info("juju topology grouping test passed for %s groups", i + 1)
+
+
+async def test_alerts_are_fired_from_non_leader_units_too(ops_test):
+    """The list of alerts must include an "AlwaysFiring" alert from each avalanche unit."""
+    alerts = await get_alertmanager_alerts(ops_test, "alertmanager", 0, retries=100)
+
+    alerts = list(filter(
+        lambda itm: itm["labels"]["alertname"] == "AlwaysFiringDueToNumericValue", alerts
+    ))
+    units_firing = sorted([alert["labels"]["juju_unit"] for alert in alerts])
+    assert units_firing == ["avalanche/0", "avalanche/1"]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -163,8 +163,8 @@ async def test_alerts_are_fired_from_non_leader_units_too(ops_test):
     """The list of alerts must include an "AlwaysFiring" alert from each avalanche unit."""
     alerts = await get_alertmanager_alerts(ops_test, "alertmanager", 0, retries=100)
 
-    alerts = list(filter(
-        lambda itm: itm["labels"]["alertname"] == "AlwaysFiringDueToNumericValue", alerts
-    ))
+    alerts = list(
+        filter(lambda itm: itm["labels"]["alertname"] == "AlwaysFiringDueToNumericValue", alerts)
+    )
     units_firing = sorted([alert["labels"]["juju_unit"] for alert in alerts])
     assert units_firing == ["avalanche/0", "avalanche/1"]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -146,7 +146,9 @@ async def test_alerts_fire_within_expected_time(ops_test: OpsTest):
         )
         return num_alerts == 2
 
-    juju.utils.block_until_with_coroutine(wait_until_all_alerts_fire, timeout=300, wait_period=15)
+    await juju.utils.block_until_with_coroutine(
+        wait_until_all_alerts_fire, timeout=300, wait_period=15
+    )
 
 
 async def test_juju_topology_labels_in_alerts(ops_test: OpsTest):

--- a/tox.ini
+++ b/tox.ini
@@ -67,8 +67,8 @@ commands =
 description = Run integration tests
 deps =
     jinja2
-    #git+https://github.com/juju/python-libjuju.git
-    juju
+    git+https://github.com/juju/python-libjuju.git
+    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =


### PR DESCRIPTION
This PR adds an itest that addresses https://github.com/canonical/prometheus-k8s-operator/pull/239:
Now that `juju_unit` is no longer added to rule files, this test confirms that alerts still fire per unit (not only from the leader unit), and are correctly labeled as such.