### PR TITLE
Add update-status itest

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -117,12 +117,12 @@ class ModelConfigChange:
         self.change_to = kwargs
 
     async def __aenter__(self):
-        """On entry, the update status interval is set to the minimum 10s."""
+        """On entry, the config is set to the user provided custom values."""
         config = await self.ops_test.model.get_config()
         self.revert_to = {k: config[k] for k in self.change_to.keys()}
         await self.ops_test.model.set_config(self.change_to)
         return self
 
     async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        """On exit, the update status interval is reverted to its original value."""
+        """On exit, the modified config options are reverted to their original values."""
         await self.ops_test.model.set_config(self.revert_to)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -107,3 +107,22 @@ async def get_alertmanager_groups(ops_test: OpsTest, unit_name, unit_num, retrie
             break
 
     return groups
+
+
+class ModelConfigChange:
+    """Context manager for temporarily changing a model config option."""
+
+    def __init__(self, ops_test: OpsTest, **kwargs):
+        self.ops_test = ops_test
+        self.change_to = kwargs
+
+    async def __aenter__(self):
+        """On entry, the update status interval is set to the minimum 10s."""
+        config = await self.ops_test.model.get_config()
+        self.revert_to = {k: config[k] for k in self.change_to.keys()}
+        await self.ops_test.model.set_config(self.change_to)
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, exc_traceback):
+        """On exit, the update status interval is reverted to its original value."""
+        await self.ops_test.model.set_config(self.revert_to)

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -24,11 +24,11 @@ from pathlib import Path
 import juju
 import pytest
 from helpers import (
+    ModelConfigChange,
     cli_deploy_bundle,
     get_alertmanager_alerts,
     get_alertmanager_groups,
     get_unit_address,
-    ModelConfigChange,
 )
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -181,7 +181,7 @@ async def test_bundle_charms_can_handle_frequent_update_status(ops_test: OpsTest
                 raise_on_error=True,
                 timeout=soak_time,
                 idle_period=soak_time,
-                check_freq=0.5
+                check_freq=0.5,
             )
         except asyncio.TimeoutError:
             # Good, this means no error during the soak time


### PR DESCRIPTION
This PR adds an itest that verifies all bundle charms can handle a frequent update-status emission.

Crossref: OPENG-687