### PR TITLE
Run itests against beta, not stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,9 @@ jobs:
     - name: Run tests (edge channel)
       if: ${{ github.event_name != 'schedule' }}
       run: tox -e integration -- --channel=edge
-    - name: Run scheduled tests (stable channel)
+    - name: Run scheduled tests (beta channel)
       if: ${{ github.event_name == 'schedule' }}
-      run: tox -e integration -- --channel=stable
+      run: tox -e integration -- --channel=beta
     - name: Run scheduled tests (edge channel)
       if: ${{ github.event_name == 'schedule' }}
       run: tox -e integration -- --channel=edge


### PR DESCRIPTION
## Issue
Stable does not exist yet, which cause itests to fail and abort.


## Solution
Run against beta instead of stable.


## Testing Instructions
Run the integration tests.


## Release Notes
Run scheduled tests against beta instead of stable.
