### PR TITLE
Self monitoring relations

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -80,6 +80,8 @@ relations:
   - prometheus:grafana-source
 - - grafana:grafana-source
   - loki:grafana-source
+- - grafana:grafana-source
+  - alertmanager:grafana-source
 - - loki:alertmanager
   - alertmanager:alerting
 {% if testing -%}
@@ -89,6 +91,16 @@ relations:
 # COS-monitoring
 - - traefik:metrics-endpoint
   - prometheus
+- - alertmanager:self-metrics-endpoint
+  - prometheus:metrics-endpoint
+- - loki:metrics-endpoint
+  - prometheus:metrics-endpoint
+- - loki:grafana-dashboard
+  - grafana:grafana-dashboard
+- - prometheus:grafana-dashboard
+  - grafana:grafana-dashboard
+- - alertmanager:grafana-dashboard
+  - grafana:grafana-dashboard
 {% if testing -%}
 --- # overlay.yaml
 applications:

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -90,7 +90,7 @@ relations:
 {% endif -%}
 # COS-monitoring
 - - traefik:metrics-endpoint
-  - prometheus
+  - prometheus:metrics-endpoint
 - - alertmanager:self-metrics-endpoint
   - prometheus:metrics-endpoint
 - - loki:metrics-endpoint

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -72,35 +72,22 @@ applications:
   {%- endif %}
 
 relations:
-- - prometheus:ingress
-  - traefik
-- - prometheus:alertmanager
-  - alertmanager:alerting
-- - grafana:grafana-source
-  - prometheus:grafana-source
-- - grafana:grafana-source
-  - loki:grafana-source
-- - grafana:grafana-source
-  - alertmanager:grafana-source
-- - loki:alertmanager
-  - alertmanager:alerting
+- [prometheus:ingress, traefik]
+- [prometheus:alertmanager, alertmanager:alerting]
+- [grafana:grafana-source, prometheus:grafana-source]
+- [grafana:grafana-source, loki:grafana-source]
+- [grafana:grafana-source, alertmanager:grafana-source]
+- [loki:alertmanager, alertmanager:alerting]
 {% if testing -%}
-- - prometheus:metrics-endpoint
-  - avalanche:metrics-endpoint
+- [prometheus:metrics-endpoint, avalanche:metrics-endpoint]
 {% endif -%}
 # COS-monitoring
-- - traefik:metrics-endpoint
-  - prometheus:metrics-endpoint
-- - alertmanager:self-metrics-endpoint
-  - prometheus:metrics-endpoint
-- - loki:metrics-endpoint
-  - prometheus:metrics-endpoint
-- - loki:grafana-dashboard
-  - grafana:grafana-dashboard
-- - prometheus:grafana-dashboard
-  - grafana:grafana-dashboard
-- - alertmanager:grafana-dashboard
-  - grafana:grafana-dashboard
+- [traefik:metrics-endpoint, prometheus:metrics-endpoint]
+- [alertmanager:self-metrics-endpoint, prometheus:metrics-endpoint]
+- [loki:metrics-endpoint, prometheus:metrics-endpoint]
+- [loki:grafana-dashboard, grafana:grafana-dashboard]
+- [prometheus:grafana-dashboard, grafana:grafana-dashboard]
+- [alertmanager:grafana-dashboard, grafana:grafana-dashboard]
 {% if testing -%}
 --- # overlay.yaml
 applications:

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -130,7 +130,6 @@ async def test_prometheus_is_up(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_prometheus_sees_alertmanager(ops_test: OpsTest):
-    am_address = await get_unit_address(ops_test, "alertmanager", 0)
     prom_url = await get_proxied_unit_url(ops_test, "prometheus", 0)
 
     response = urllib.request.urlopen(f"{prom_url}/api/v1/alertmanagers", data=None, timeout=2.0)
@@ -139,10 +138,9 @@ async def test_prometheus_sees_alertmanager(ops_test: OpsTest):
     # an empty response looks like this:
     # {"status":"success","data":{"activeAlertmanagers":[],"droppedAlertmanagers":[]}}
     # a jsonified activeAlertmanagers looks like this:
-    # [{'url': 'http://10.1.179.124:9093/api/v1/alerts'}]
+    # [{'url': 'http://FQDN:9093/api/v2/alerts'}]
     assert any(
-        f"http://{am_address}:9093" in am["url"]
-        for am in alertmanagers["data"]["activeAlertmanagers"]
+        ":9093/api/v2/alerts" in am["url"] for am in alertmanagers["data"]["activeAlertmanagers"]
     )
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR adds new self-monitoring and dashboards relations:

```yaml
- - grafana:grafana-source
  - alertmanager:grafana-source
- - alertmanager:self-metrics-endpoint
  - prometheus:metrics-endpoint
- - loki:metrics-endpoint
  - prometheus:metrics-endpoint
- - loki:grafana-dashboard
  - grafana:grafana-dashboard
- - prometheus:grafana-dashboard
  - grafana:grafana-dashboard
- - alertmanager:grafana-dashboard
  - grafana:grafana-dashboard
```


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Deploy this bundle, and check:

- There are Alertmanager, Prometheus, and Loki Datasources
- There are Alertmanager, Prometheus, and Loki Dashboards

