### PR TITLE
add catalogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .tox/
 .mypy_cache/
 build/
+cos-lite.yaml

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -45,6 +45,16 @@ applications:
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
+  catalogue:
+    charm: {{ catalogue|default('catalogue-k8s', true) }}
+    scale: 1
+    trust: true
+    {%- if catalogue is defined and catalogue.endswith('.charm') %}
+    resources:
+      catalogue-image: "ghcr.io/canonical/catalogue-k8s"
+    {%- else %}
+    channel: {{ channel|default('edge', true) }}
+    {%- endif %}
   loki:
     charm: {{ loki|default('loki-k8s', true) }}
     scale: 1
@@ -89,6 +99,12 @@ relations:
 - [loki:grafana-dashboard, grafana:grafana-dashboard]
 - [prometheus:grafana-dashboard, grafana:grafana-dashboard]
 - [alertmanager:grafana-dashboard, grafana:grafana-dashboard]
+# Service Catalogue
+- [catalogue:ingress, traefik:ingress],
+- [catalogue:catalogue, grafana:catalogue]
+- [catalogue:catalogue, prometheus:catalogue]
+- [catalogue:catalogue, alertmanager:catalogue]
+
 {% if testing -%}
 --- # overlay.yaml
 applications:

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -60,7 +60,7 @@ applications:
       tagline: Model-driven Observability Stack deployed with a single command.
       description: |
         Canonical Observability Stack Lite, or COS Lite, is a light-weight, highly-integrated, 
-	Juju-based observability suite running on Kubernetes.
+        Juju-based observability suite running on Kubernetes.
   loki:
     charm: {{ loki|default('loki-k8s', true) }}
     scale: 1

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -55,6 +55,12 @@ applications:
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
+    options:
+      title: Canonical Observability Stack
+      tagline: Model-driven Observability Stack deployed with a single command.
+      description: |
+        Canonical Observability Stack Lite, or COS Lite, is a light-weight, highly-integrated, 
+	Juju-based observability suite running on Kubernetes.
   loki:
     charm: {{ loki|default('loki-k8s', true) }}
     scale: 1

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -106,7 +106,7 @@ relations:
 - [prometheus:grafana-dashboard, grafana:grafana-dashboard]
 - [alertmanager:grafana-dashboard, grafana:grafana-dashboard]
 # Service Catalogue
-- [catalogue:ingress, traefik:ingress],
+- [catalogue:ingress, traefik:ingress]
 - [catalogue:catalogue, grafana:catalogue]
 - [catalogue:catalogue, prometheus:catalogue]
 - [catalogue:catalogue, alertmanager:catalogue]

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,13 @@ passenv =
   HTTPS_PROXY
   NO_PROXY
 
+[testenv:render]
+description = Render a charm bundle from the Jinja template
+deps =
+    jinja2
+commands =
+    ./render_bundle.py cos-lite.yaml
+
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =


### PR DESCRIPTION
> ### ⚠️ Depends on other PRs 
>
> Do not merge this until https://github.com/canonical/alertmanager-k8s-operator/pull/101 is merged.

## Issue
Add catalogue to the bundle.

## Solution
Add deployment, configuration, and relations for the catalogue charm.
Once merged, a new bundle needs to be deployed.


## Testing Instructions
- Render bundle
- Deploy bundle
- Access the catalogue on port 80
- Make sure all entries are there with sane details

## Release Notes
Add service catalogue to bundle