### PR TITLE
Add ingress for Alertmanager

### DIFF
--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -29,7 +29,7 @@ subgraph cos_lite["COS Lite"]
   trfk --- |<a href='https://charmhub.io/traefik-k8s/libraries/ingress_per_unit'>ipu</a>| loki
   trfk --- |ipu| prom
   trfk --- |<a href='https://charmhub.io/traefik-route-k8s/libraries/traefik_route'>route</a>| graf
-  trfk -.- |<a href='https://charmhub.io/traefik-k8s/libraries/ingress'>ipa</a>| alrt
+  trfk --- |<a href='https://charmhub.io/traefik-k8s/libraries/ingress'>ipa</a>| alrt
 
   prom --- |<a href='https://charmhub.io/catalogue-k8s/libraries/catalogue'>catalogue</a>| ctlg
   alrt --- |catalogue| ctlg

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -91,6 +91,7 @@ relations:
 - [traefik:ingress-per-unit, prometheus:ingress]
 - [traefik:ingress-per-unit, loki:ingress]
 - [traefik:traefik-route, grafana:ingress]
+- [traefik:ingress, alertmanager:ingress]
 - [prometheus:alertmanager, alertmanager:alerting]
 - [grafana:grafana-source, prometheus:grafana-source]
 - [grafana:grafana-source, loki:grafana-source]


### PR DESCRIPTION
## Issue
Alertmanager was not ingressed, making it's UI inaccessible from outside of the cluster.

## Solution
Add an ingress relation to the bundle

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- Deploy bundle
- Access the catalogue
- Navigate using the link provided by the UI

## Release Notes
<!-- A digestable summary of the change in this PR -->
Add ingress relation for Alertmanager
