### PR TITLE
add test to check prometheus scraping loki through traefik

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -28,7 +28,7 @@ async def reenable_metallb() -> str:
 
     logger.info("First, disable metallb, just in case")
     try:
-        cmd = ["sg", "microk8s", "-c", "microk8s disable metallb"]
+        cmd = ["sg", "snap_microk8s", "-c", "sudo microk8s disable metallb"]
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except Exception as e:
         print(e)
@@ -38,7 +38,7 @@ async def reenable_metallb() -> str:
 
     logger.info("Now enable metallb")
     try:
-        cmd = ["sg", "microk8s", "-c", f"microk8s enable metallb:{ip}-{ip}"]
+        cmd = ["sg", "snap_microk8s", "-c", f"sudo microk8s enable metallb:{ip}-{ip}"]
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except Exception as e:
         print(e)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -28,7 +28,7 @@ async def reenable_metallb() -> str:
 
     logger.info("First, disable metallb, just in case")
     try:
-        cmd = ["sg", "snap_microk8s", "-c", "sudo microk8s disable metallb"]
+        cmd = ["sg", "microk8s", "-c", "microk8s disable metallb"]
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except Exception as e:
         print(e)
@@ -38,7 +38,7 @@ async def reenable_metallb() -> str:
 
     logger.info("Now enable metallb")
     try:
-        cmd = ["sg", "snap_microk8s", "-c", f"sudo microk8s enable metallb:{ip}-{ip}"]
+        cmd = ["sg", "microk8s", "-c", f"microk8s enable metallb:{ip}-{ip}"]
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except Exception as e:
         print(e)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -64,7 +64,8 @@ async def cli_deploy_bundle(ops_test: OpsTest, name: str, channel: str = "edge")
     retcode, stdout, stderr = await ops_test.run(*run_args)
     assert retcode == 0, f"Deploy failed: {(stderr or stdout).strip()}"
     logger.info(stdout)
-    await ops_test.model.wait_for_idle(timeout=1000)
+    # FIXME: raise_on_error should be removed (i.e. set to True) when units stop flapping to error
+    await ops_test.model.wait_for_idle(timeout=1000, raise_on_error=False)
 
 
 async def get_proxied_unit_url(ops_test: OpsTest, app_name: str, unit_num: int) -> str:

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -41,6 +41,8 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     Assert on the unit status before any relations/configurations take place.
     """
+    await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
+
     await reenable_metallb()
 
     logger.info("Rendering bundle %s", get_this_script_dir() / ".." / ".." / "bundle.yaml.j2")
@@ -78,7 +80,8 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     # use CLI to deploy bundle until https://github.com/juju/python-libjuju/issues/511 is fixed.
     await cli_deploy_bundle(ops_test, str(rendered_bundle))
-    await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    # FIXME: raise_on_error should be removed (i.e. set to True) when units stop flapping to error
+    await ops_test.model.wait_for_idle(status="active", timeout=1000, raise_on_error=False)
 
     prometheus_0_url = await get_proxied_unit_url(ops_test, app_name="prometheus", unit_num=0)
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -218,7 +218,7 @@ async def test_loki_receives_logs_through_traefik(ops_test: OpsTest):
     """Loki should be able to receive logs through its traefik endpoint."""
     loki_url = await get_proxied_unit_url(ops_test, "loki", 0)
 
-    ops_test.model.deploy("zinc-k8s", application_name="zinc", channel="stable", trust=True)
+    await ops_test.model.deploy("zinc-k8s", application_name="zinc", channel="stable", trust=True)
     await ops_test.model.wait_for_idle(status="active")
     # Create the relation
     await ops_test.model.add_relation("loki", "zinc")

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -209,7 +209,7 @@ async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
     assert response.code == 200
     targets = json.loads(response.read())["data"]["activeTargets"]
     targets_summary = [(t["discoveredLabels"]["__metrics_path__"], t["health"]) for t in targets]
-    assert ("cos-lite-loki-0/metrics", "up") in targets_summary
+    assert (f"/{ops_test.model.name}-loki-0/metrics", "up") in targets_summary
     logger.info("prometheus is successfully scraping loki through traefik")
 
 
@@ -223,7 +223,7 @@ async def test_loki_receives_logs_through_traefik(ops_test: OpsTest):
     await ops_test.model.add_relation("loki", "zinc")
     await ops_test.model.wait_for_idle(status="active")
     # Check that logs are coming in
-    response = urllib.request.urlopen(f"{loki_url}/api/v1/series")
+    response = urllib.request.urlopen(f"{loki_url}/loki/api/v1/series")
     assert response.code == 200
     series = json.loads(response.read())["data"]
     series_charms = [s["juju_charm"] for s in series]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -210,7 +210,7 @@ async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
     assert response.code == 200
     targets = json.loads(response.read())["data"]["activeTargets"]
     targets_summary = [(t["scrapeUrl"], t["health"]) for t in targets]
-    assert (loki_url, "up") in targets_summary
+    assert (f"{loki_url}/metrics", "up") in targets_summary
     logger.info("prometheus is successfully scraping loki through traefik")
 
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -204,13 +204,12 @@ async def test_bundle_charms_can_handle_frequent_update_status(ops_test: OpsTest
 async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
     """Prometheus should correctly scrape Loki through its traefik endpoint."""
     prom_url = await get_proxied_unit_url(ops_test, "prometheus", 0)
-    loki_url = await get_proxied_unit_url(ops_test, "loki", 0)
 
     response = urllib.request.urlopen(f"{prom_url}/api/v1/targets", data=None, timeout=2.0)
     assert response.code == 200
     targets = json.loads(response.read())["data"]["activeTargets"]
-    targets_summary = [(t["scrapeUrl"], t["health"]) for t in targets]
-    assert (f"{loki_url}/metrics", "up") in targets_summary
+    targets_summary = [(t["discoveredLabels"]["__metrics_path__"], t["health"]) for t in targets]
+    assert ("cos-lite-loki-0/metrics", "up") in targets_summary
     logger.info("prometheus is successfully scraping loki through traefik")
 
 


### PR DESCRIPTION
## Issue
This addresses the first part of https://github.com/canonical/loki-k8s-operator/issues/211.

## Release Notes
This PR adds an integration test to make sure Prometheus is correctly scraping Loki when Loki is behind traefik.