### PR TITLE
Fix itest failure

### DIFF
--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -80,8 +80,9 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 
     # use CLI to deploy bundle until https://github.com/juju/python-libjuju/issues/511 is fixed.
     await cli_deploy_bundle(ops_test, str(rendered_bundle))
+    # Idle period is set to 90 to capture restarts caused by applying resource limits
     # FIXME: raise_on_error should be removed (i.e. set to True) when units stop flapping to error
-    await ops_test.model.wait_for_idle(status="active", timeout=1000, raise_on_error=False)
+    await ops_test.model.wait_for_idle(status="active", timeout=1000, idle_period=90, raise_on_error=False)
 
     prometheus_0_url = await get_proxied_unit_url(ops_test, app_name="prometheus", unit_num=0)
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -82,7 +82,9 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
     await cli_deploy_bundle(ops_test, str(rendered_bundle))
     # Idle period is set to 90 to capture restarts caused by applying resource limits
     # FIXME: raise_on_error should be removed (i.e. set to True) when units stop flapping to error
-    await ops_test.model.wait_for_idle(status="active", timeout=1000, idle_period=90, raise_on_error=False)
+    await ops_test.model.wait_for_idle(
+        status="active", timeout=1000, idle_period=90, raise_on_error=False
+    )
 
     prometheus_0_url = await get_proxied_unit_url(ops_test, app_name="prometheus", unit_num=0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ basepython = python3
 setenv =
   PYTHONPATH = {toxinidir}
   PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
 passenv =
   PYTHONPATH
   HOME
@@ -85,7 +86,7 @@ deps =
     pytest
     pytest-operator==1.0.0b1
 commands =
-    pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration
+    pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/integration
 
 [testenv:render-{edge,beta,candidate,stable}]
 description = Render the bundle from template


### PR DESCRIPTION
## Issue
CI [fails](https://github.com/canonical/cos-lite-bundle/actions/runs/3753467540/jobs/6376759562) because loki is not yet seen as "up" by prom:
```
_________________ test_prometheus_scrapes_loki_through_traefik _________________
Traceback (most recent call last):
  File "/home/runner/work/cos-lite-bundle/cos-lite-bundle/tests/integration/test_bundle.py", line 212, in test_prometheus_scrapes_loki_through_traefik
    assert (f"/{ops_test.model.name}-loki-0/metrics", "up") in targets_summary
AssertionError: assert ('/test-bundle-doxh-loki-0/metrics', 'up') in [('/test-bundle-doxh-alertmanager/metrics', 'up'), ('/metrics', 'up'), ('/metrics', 'up'), ('/metrics', 'up'), ('/metrics', 'up'), ('/metrics', 'up'), ...]
```


## Solution
- Force an idle period of 90s for bundle deployment.


## Context
NTA.


## Testing Instructions
Run itests on github.


## Release Notes
Fix itest failure.
