### PR TITLE
Always run edge itests first

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,13 @@ jobs:
         provider: microk8s
         bootstrap-options: "--agent-version 2.9.34"
     - name: Run tests (edge channel)
-      if: ${{ github.event_name != 'schedule' }}
       run: tox -e integration -- --channel=edge
-    - name: Run scheduled tests (beta channel)
+    - name: Run tests (beta channel)
       if: ${{ github.event_name == 'schedule' }}
       run: tox -e integration -- --channel=beta
-    - name: Run scheduled tests (edge channel)
+    - name: Run tests (candidate channel)
       if: ${{ github.event_name == 'schedule' }}
-      run: tox -e integration -- --channel=edge
+      run: tox -e integration -- --channel=candidate
+    - name: Run tests (stable channel)
+      if: ${{ github.event_name == 'schedule' }}
+      run: tox -e integration -- --channel=stable


### PR DESCRIPTION
## Issue
Before this PR, a scheduled CI failed all steps because the workflow first attempts to run the tests on the "beta" channel.

## Solution
This PR changes the order a bit, so that the edge channel is tested first.
This way, when reviewing failed CI runs it would be more obvious when edge passes but the others fails.
The PR also adds steps to run scheduled CI on the other channels (candidate and stable).


## Context
NTA.


## Testing Instructions
- Make sure CI passes for edge.


## Release Notes
Always run edge itests first.
