### PR TITLE
Add scheduled integration matrix in separate workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,10 @@
 name: Test Suite
+
 on:
   pull_request:
   push:
     branches:
       - main
-  schedule:
-    # every Wednesday at 23:00
-    - cron: '0 23 * * WED'
 
 jobs:
   lint:
@@ -42,12 +40,3 @@ jobs:
         bootstrap-options: "--agent-version 2.9.34"
     - name: Run tests (edge channel)
       run: tox -e integration -- --channel=edge
-    - name: Run tests (beta channel)
-      if: ${{ github.event_name == 'schedule' }}
-      run: tox -e integration -- --channel=beta
-    - name: Run tests (candidate channel)
-      if: ${{ github.event_name == 'schedule' }}
-      run: tox -e integration -- --channel=candidate
-    - name: Run tests (stable channel)
-      if: ${{ github.event_name == 'schedule' }}
-      run: tox -e integration -- --channel=stable

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -1,0 +1,34 @@
+name: Periodic integration matrix tests
+
+on:
+  schedule:
+    # every Wednesday at 23:00
+    - cron: '0 23 * * WED'
+
+jobs:
+  integration-test-microk8s-pull-request:
+    name: Integration tests (microk8s)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        charm-channel: [ "edge", "beta", "candidate", "stable" ]
+        juju-channel: [ "2.9/stable", "3.0/stable" ]
+        include:
+          - juju-channel: "2.9/stable"
+            juju-agent-version: "2.9.34"
+            microk8s-channel: "1.25/stable"
+          - juju-channel: "3.0/stable"
+            juju-agent-version: "3.0.2"
+            microk8s-channel: "1.25-strict/stable"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup operator environment
+      uses: charmed-kubernetes/actions-operator@main
+      with:
+        juju-channel: ${{ matrix.juju-channel }}
+        provider: microk8s
+        channel: ${{ matrix.microk8s-channel }}
+        bootstrap-options: "--agent-version ${{ matrix.juju-agent-version }}"
+    - name: Run tests (${{ matrix.charm-channel }} charms, juju ${{ matrix.juju-channel }}, microk8s ${{ matrix.microk8s-channel }})
+      run: tox -e integration -- --channel=${{ matrix.charm-channel }}

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -4,12 +4,15 @@ on:
   schedule:
     # every Wednesday at 23:00
     - cron: '0 23 * * WED'
+  workflow_call:
+
 
 jobs:
   integration-test-microk8s-pull-request:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         charm-channel: [ "edge", "beta", "candidate", "stable" ]
         juju-channel: [ "2.9/stable", "3.0/stable" ]


### PR DESCRIPTION
## Issue
Currently,
- Scheduled CI fails if any channel fails, because steps are sequential.
- Only testing for juju 2.9.34.


## Solution
Add matrix tests and split out the scheduled event from the PR/push events.

Fixes #59.

Ref: [Expanding or adding matrix configurations](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations)


## Context
NTA.


## Testing Instructions
Make sure all intended matrix items run.


## Release Notes
Add scheduled integration matrix in separate workflow.
