### PR TITLE
Fix trigger name for manual invocation

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # every Wednesday at 23:00
     - cron: '0 23 * * WED'
-  workflow_call:
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
## Issue
#60 added `workflow_call`, which is used in reusable workflows. Here we need `workflow_dispatch`.

## Solution
Change to `workflow_dispatch`.

## Release Notes
Fix trigger name for manual invocation
