### PR TITLE
Enable metallb in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,15 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Get prefsrc
+      run: |
+        echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
         juju-channel: 2.9/stable
         provider: microk8s
+        microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
         bootstrap-options: "--agent-version 2.9.34"
     - name: Run tests (edge channel)
       run: tox -e integration -- --channel=edge

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -26,12 +26,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Get prefsrc
+      run: |
+        echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
         juju-channel: ${{ matrix.juju-channel }}
         provider: microk8s
         channel: ${{ matrix.microk8s-channel }}
+        microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
         bootstrap-options: "--agent-version ${{ matrix.juju-agent-version }}"
     - name: Run tests (${{ matrix.charm-channel }} charms, juju ${{ matrix.juju-channel }}, microk8s ${{ matrix.microk8s-channel }})
       run: tox -e integration -- --channel=${{ matrix.charm-channel }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,9 +3,6 @@
 
 import logging
 
-import pytest
-from helpers import disable_metallb, enable_metallb
-
 logger = logging.getLogger(__name__)
 
 
@@ -18,11 +15,3 @@ def pytest_addoption(parser):
     parser.addoption("--loki", action="store")
     parser.addoption("--avalanche", action="store")
     parser.addoption("--channel", action="store")
-
-
-@pytest.fixture(scope="module", autouse=True)
-async def reenable_metallb():
-    logger.info("First, disable metallb, in case it's enabled")
-    await disable_metallb()
-    logger.info("Now enable metallb")
-    await enable_metallb()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,13 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
+
+import pytest
+from helpers import disable_metallb, enable_metallb
+
+logger = logging.getLogger(__name__)
+
 
 def pytest_addoption(parser):
     # not providing the "default" arg to addoption: the bundle template already specifies defaults
@@ -11,3 +18,11 @@ def pytest_addoption(parser):
     parser.addoption("--loki", action="store")
     parser.addoption("--avalanche", action="store")
     parser.addoption("--channel", action="store")
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def reenable_metallb():
+    logger.info("First, disable metallb, in case it's enabled")
+    await disable_metallb()
+    logger.info("Now enable metallb")
+    await enable_metallb()

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -20,7 +20,7 @@ from helpers import (
     get_alertmanager_alerts,
     get_alertmanager_groups,
     get_proxied_unit_url,
-    get_unit_address,
+    get_address,
 )
 from pytest_operator.plugin import OpsTest
 
@@ -97,7 +97,7 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
 @pytest.mark.abort_on_fail
 async def test_alertmanager_is_up(ops_test: OpsTest):
     # TODO Change this when AM is exposed over the ingress
-    address = await get_unit_address(ops_test, "alertmanager", 0)
+    address = await get_address(ops_test, "alertmanager", 0)
     # With ingress in place, need to use model-app as ingress-per-app subpath
     url = f"http://{address}:9093/{ops_test.model_name}-alertmanager"
     logger.info("am public address: %s", url)

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -21,7 +21,6 @@ from helpers import (
     get_alertmanager_groups,
     get_proxied_unit_url,
     get_unit_address,
-    reenable_metallb,
 )
 from pytest_operator.plugin import OpsTest
 
@@ -42,8 +41,6 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
     Assert on the unit status before any relations/configurations take place.
     """
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
-
-    await reenable_metallb()
 
     logger.info("Rendering bundle %s", get_this_script_dir() / ".." / ".." / "bundle.yaml.j2")
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -17,10 +17,10 @@ import pytest
 from helpers import (
     ModelConfigChange,
     cli_deploy_bundle,
+    get_address,
     get_alertmanager_alerts,
     get_alertmanager_groups,
     get_proxied_unit_url,
-    get_address,
 )
 from pytest_operator.plugin import OpsTest
 


### PR DESCRIPTION
## Issue
Currently, metallb is enabled from within the itest itself.


## Solution
Enable metallb in CI instead. (For local testing would need to have a devenv with metallb already enabled.)


## Release Notes
Enable metallb in CI.
