### PR TITLE
Add Juju 3.1.0 to the matrix test

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -15,13 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         charm-channel: [ "edge", "beta", "candidate", "stable" ]
-        juju-channel: [ "2.9/stable", "3.0/stable" ]
+        juju-channel: [ "2.9/stable", "3.0/stable", "3.1/stable" ]
         include:
           - juju-channel: "2.9/stable"
             juju-agent-version: "2.9.34"
             microk8s-channel: "1.25/stable"
           - juju-channel: "3.0/stable"
             juju-agent-version: "3.0.2"
+            microk8s-channel: "1.25-strict/stable"
+          - juju-channel: "3.1/stable"
+            juju-agent-version: "3.1.0"
             microk8s-channel: "1.25-strict/stable"
     steps:
     - name: Checkout

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -8,8 +8,8 @@ on:
 
 
 jobs:
-  integration-test-microk8s-pull-request:
-    name: Integration tests (microk8s)
+  integration-matrix:
+    name: Matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Issue
A new minor version of juju is out and we need to itest on it.


## Solution
- Add Juju 3.1.0 to the matrix test
- Keep 3.0.2 for now. We need to know if we'd need to exclude it in our `assumes` sections.
- Shorten job name so matrix params are visible in the sidebar
![image](https://user-images.githubusercontent.com/82407168/217076348-6dc0f056-6173-4ef2-86b0-31d4543ecd7d.png)


## Release Notes
Add Juju 3.1.0 to the matrix test
