### PR TITLE
Pin pylibjuju to 3.0.x

### DIFF
--- a/tests/load/gcp/prom-query/README.md
+++ b/tests/load/gcp/prom-query/README.md
@@ -20,7 +20,7 @@ curl http://pd-ssd-4cpu-8gb.us-central1-a.c.lma-light-load-testing.internal/cos-
 sudo iftop -i ens4 -f "host pd-ssd-4cpu-8gb.c.lma-light-load-testing.internal"
 ```
 
-### Manually run the test in your browser
+### Manually run the test in your browser (zombie)
 
 First, copy rendered files from the VM:
 
@@ -39,6 +39,16 @@ $ scp -i ~/secrets/cos-lite-load-testing-ssh \
 Set up an ssh tunnel with DNS lookups:
 ```
 sudo sshuttle --dns -r ubuntu@35.184.199.203 0/0 --ssh-cmd 'ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking no" -i /home/user/secrets/cos-lite-load-testing-ssh'
+```
+
+Alternatively, change the login hostname to `localhost:8080` and set up an ssh tunnel with the `-L` flag:
+
+```
+ssh -i ~/secrets/cos-lite-load-testing-ssh \
+    -o "UserKnownHostsFile=/dev/null" \
+    -o "StrictHostKeyChecking no" \
+    -L localhost:8080:10.128.0.7:80 \
+    ubuntu@35.184.199.203
 ```
 
 Run the test (a browser window should pop up):

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ commands =
 description = Run integration tests
 deps =
     jinja2
-    juju
+    juju~=3.0.0
     pytest
     pytest-operator==1.0.0b1
 commands =


### PR DESCRIPTION
## Issue
Latest pylibjuju [dropped support](https://github.com/juju/python-libjuju/pull/774) for Juju 2.9.
As a result, the matrix tests now fail on Juju 2.9.


## Solution
As we transition from Juju 2.9 to 3, pin pylibjuju to 3.0.x, which supports both 2.9 and 3.

> the approach we will follow is to use the latest python-libjuju that matches the juju release (2.9.38.1 -> 2.9.38, 3.1.0.1 -> 3.1.0)
>
> -- @juanmanuel-tirado 


> Juju API Server maintains compatibility within a major series.
So if we release an API method with 3.0, then we will continue to allow you to make that request with Juju 3.1, or 3.2, etc.
However, it is fairly clear that a 3.0 candidate won't know how to do things that we introduced in 3.1 (eg user secrets when they land in 3.2 will only be supported by pylibjuju-3.2+)
> 
> Across a major version change, we decided to give you 1 version (python-libjuju-3.0*) that supports both 2.9 and 3.0, but libjuju-3.1 is dropping support for 2.9
>
> For your specific request, python-libjuju 3.0.* should be a bridge version that supports both, and as long as you aren't trying to do "new things" with 3.1+ should be valid.
>
> -- @jameinel 



## Release Notes
Pin pylibjuju to 3.0.x.
