### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ line-length = 99
 target-version = ["py38"]
 exclude = "\\.tpl\\.py$"
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,22 +18,21 @@ exclude = "\\.tpl\\.py$"
 profile = "black"
 
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "*.tpl.py", ".terraform*"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info", "*.tpl.py", ".terraform*"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -50,18 +50,18 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig):
             option = str(await ops_test.build_charm(option))
         return option
 
-    charms = dict(
-        traefik=pytestconfig.getoption("traefik"),
-        alertmanager=pytestconfig.getoption("alertmanager"),
-        prometheus=pytestconfig.getoption("prometheus"),
-        grafana=pytestconfig.getoption("grafana"),
-        loki=pytestconfig.getoption("loki"),
-        avalanche=pytestconfig.getoption("avalanche"),
-    )
+    charms = {
+        "traefik": pytestconfig.getoption("traefik"),
+        "alertmanager": pytestconfig.getoption("alertmanager"),
+        "prometheus": pytestconfig.getoption("prometheus"),
+        "grafana": pytestconfig.getoption("grafana"),
+        "loki": pytestconfig.getoption("loki"),
+        "avalanche": pytestconfig.getoption("avalanche"),
+    }
 
-    additional_args = dict(
-        channel=pytestconfig.getoption("channel"),
-    )
+    additional_args = {
+        "channel": pytestconfig.getoption("channel"),
+    }
 
     context = {k: await build_charm_if_is_dir(v) for k, v in charms.items() if v is not None}
     context.update(additional_args)

--- a/tests/load/gcp/plot.py
+++ b/tests/load/gcp/plot.py
@@ -128,7 +128,7 @@ for i, (x_label, y_label) in enumerate(to_plot):
     x, y = np.array(data_without_nans[x_label]), np.array(data_without_nans[y_label])
 
     popt, _ = curve_fit(fit_linear, x, y)
-    y_fit = list(map(lambda x_: fit_linear(x_, *popt), x))
+    y_fit = [fit_linear(x_, *popt) for x_ in x]
     ax.plot(x, y_fit, "k--")
     ax.text((min(x) + max(x)) / 2, (min(y) + max(y)) / 2, str(popt))
 fig.suptitle("Per-pod resource usage")

--- a/tox.ini
+++ b/tox.ini
@@ -28,30 +28,22 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    # Need to override pflake8's default exclude patterns, which include '.tpl.py'
-    pflake8 --exclude .terraform {[vars]tst_path}/load
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
+    # Need to override ruff's default exclude patterns, which include '.tpl.py'
+    ruff --exclude .terraform {[vars]tst_path}/load
     black --extend-exclude '/\.terraform/' --check --diff {[vars]all_path}
 
 [testenv:static-{bundle,integration,load}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which wasn't checked before anyway): 
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.