### PR TITLE
[itest] Use model_name instead of model.name

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -48,3 +48,35 @@ jobs:
         bootstrap-options: "--agent-version ${{ matrix.juju-agent-version }}"
     - name: Run tests (${{ matrix.charm-channel }} charms, juju ${{ matrix.juju-channel }}, microk8s ${{ matrix.microk8s-channel }})
       run: tox -e integration -- --channel=${{ matrix.charm-channel }}
+    - name: Dump debug log
+      if: failure()
+      run: for m in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $m --replay --ms --no-tail; done
+      shell: bash
+    - name: Dump charmcraft logs
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: charmcraft-logs
+        path: ~/.local/state/charmcraft/log/*.log
+    - name: Dump deployments
+      if: failure()
+      run: kubectl describe deployments -A
+    - name: Dump replicasets
+      if: failure()
+      run: kubectl describe replicasets -A
+    - name: Dump pods and their logs
+      if: failure()
+      shell: bash
+      run: |
+        juju status --relations --storage
+        kubectl get pods \
+            -A \
+            -o=jsonpath='{range.items[*]}{.metadata.namespace} {.metadata.name}{"\n"}' \
+            --sort-by=.metadata.namespace \
+            | grep -v "^\s*$" \
+            | while read namespace pod; do \
+                 kubectl -n $namespace describe pod $pod; \
+                 kubectl -n $namespace logs $pod \
+                    --all-containers=true \
+                    --tail=100; \
+             done

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -187,7 +187,7 @@ async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
     assert response.code == 200
     targets = json.loads(response.read())["data"]["activeTargets"]
     targets_summary = [(t["discoveredLabels"]["__metrics_path__"], t["health"]) for t in targets]
-    assert (f"/{ops_test.model.name}-loki-0/metrics", "up") in targets_summary
+    assert (f"/{ops_test.model_name}-loki-0/metrics", "up") in targets_summary
     logger.info("prometheus is successfully scraping loki through traefik")
 
 


### PR DESCRIPTION
## Issue
Matrix tests for Juju 2.9 [fail](https://github.com/canonical/cos-lite-bundle/actions/runs/5406674418/jobs/9823830823) for:
```
  File "/home/runner/work/cos-lite-bundle/cos-lite-bundle/tests/integration/test_bundle.py", line 190, in test_prometheus_scrapes_loki_through_traefik
    assert (f"/{ops_test.model.name}-loki-0/metrics", "up") in targets_summary
AttributeError: 'Model' object has no attribute 'name'
```

This is because [`Model.name` is not available in v2.9](https://github.com/juju/python-libjuju/issues/893).


## Solution
- Use [`ops_test.model_name`](https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md#model_name) instead.
- Dump logs so we have further insight into https://bugs.launchpad.net/bugs/2025411

## Context
NTA.


## Testing Instructions
`tox -e integration` with Juju 2.9.


## Release Notes
Fix itest so it's runnable with Juju 2.9.
