### PR TITLE
Add tls overlay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
-        juju-channel: 2.9/stable
+        juju-channel: 3.1/stable
         provider: microk8s
         channel: 1.25-strict/stable
         microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
@@ -50,7 +50,9 @@ jobs:
       run: tox -e integration -- --channel=edge
     - name: Dump debug log
       if: failure()
-      run: for ctl in $(juju controllers --format json | jq -r '.controllers | keys[]'); do for mdl in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $ctl:$mdl --replay --ms --no-tail; done; done || true
+      run: |
+        for ctl in $(juju controllers --format json | jq -r '.controllers | keys[]'); do for mdl in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $ctl:$mdl --replay --ms --no-tail; done; done || true
+        exit 0
       shell: bash
   end-to-end-tests:
     # Must use Juju 3 to bootstrap both uk8s and lxd:https://bugs.launchpad.net/juju/+bug/2003582
@@ -66,7 +68,7 @@ jobs:
       - name: Setup lxd controller
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 2.9/stable
+          juju-channel: 3.1/stable
           provider: lxd
       - name: Save lxd controller name
         id: lxd-controller
@@ -75,7 +77,7 @@ jobs:
       - name: Setup k8s controller
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 2.9/stable
+          juju-channel: 3.1/stable
           provider: microk8s
           channel: 1.25-strict/stable
           microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
         python: [3.8]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get prefsrc
       run: |
         echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         charm-channel: [ "edge", "beta", "candidate", "stable" ]
-        juju-channel: [ "2.9/stable", "3.2/stable" ]
+        juju-channel: [ "3.1/stable", "3.2/stable" ]
         include:
-          - juju-channel: "2.9/stable"
-            juju-agent-version: "2.9.34"
+          - juju-channel: "3.1/stable"
+            juju-agent-version: "3.1.5"
             microk8s-channel: "1.25/stable"
           - juju-channel: "3.2/stable"
             juju-agent-version: "3.2.0"

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -27,7 +27,7 @@ jobs:
             microk8s-channel: "1.25-strict/stable"
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get prefsrc
       run: |
         echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,13 +52,12 @@ This would include a tester charm (avalanche) and an overlay section with offers
 Optionally, you may render the template with local charms, for example:
 
 ```shell
-./render_bundle.py bundle.yaml --testing=yes --channel=edge \
+./render_bundle.py bundle.yaml --channel=edge \
   --traefik=$(pwd)/../traefik-k8s-operator/traefik-k8s_ubuntu-20.04-amd64.charm \
   --prometheus=$(pwd)/../prometheus-k8s-operator/prometheus-k8s_ubuntu-20.04-amd64.charm \
   --alertmanager=$(pwd)/../alertmanager-k8s-operator/alertmanager-k8s_ubuntu-20.04-amd64.charm \
   --grafana=$(pwd)/../grafana-k8s-operator/grafana-k8s_ubuntu-20.04-amd64.charm \
-  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm \
-  --avalanche=$(pwd)/../avalanche-k8s-operator/avalanche-k8s_ubuntu-20.04-amd64.charm
+  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm
 ```
 
 #### Render template using tox
@@ -70,8 +69,7 @@ tox -e integration -- --keep-models -k test_build_and_deploy \
   --prometheus=$(pwd)/../prometheus-k8s-operator/prometheus-k8s_ubuntu-20.04-amd64.charm \
   --alertmanager=$(pwd)/../alertmanager-k8s-operator/alertmanager-k8s_ubuntu-20.04-amd64.charm \
   --grafana=$(pwd)/../grafana-k8s-operator/grafana-k8s_ubuntu-20.04-amd64.charm \
-  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm \
-  --avalanche=$(pwd)/../avalanche-k8s-operator/avalanche-k8s_ubuntu-20.04-amd64.charm
+  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm
 ```
 
 Now `juju switch` into the newly created model (or use `--model=MODEL` in
@@ -121,6 +119,5 @@ tox -e integration -- \
   --prometheus=$(pwd)/../prometheus-k8s-operator/prometheus-k8s_ubuntu-20.04-amd64.charm \
   --alertmanager=$(pwd)/../alertmanager-k8s-operator/alertmanager-k8s_ubuntu-20.04-amd64.charm \
   --grafana=$(pwd)/../grafana-k8s-operator/grafana-k8s_ubuntu-20.04-amd64.charm \
-  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm \
-  --avalanche=$(pwd)/../avalanche-k8s-operator/avalanche-k8s_ubuntu-20.04-amd64.charm
+  --loki=$(pwd)/../loki-operator/loki-k8s-operator_ubuntu-20.04-amd64.charm
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The Canonical Observability Stack is the go-to solution for monitoring Canonical
 With COS Lite now being generally available, we are now working on a highly-available, highly-scalable flavor. It will use many of the same components as COS Lite, plus some additional new ones, and provide the same overall user-experience, and focus on scalability, resilience and broad compatibility with Kubernetes distributions out there.
 
 ## Usage
+For traefik ingress to work, you may first need to enable the `metallb`
+microk8s addon. See the [tutorial] for full details.
+
+The `--trust` option is needed by the charms in the `cos-lite` bundle to be
+able to patch their K8s services to:
+- use the right ports (see this [Juju limitation](https://bugs.launchpad.net/juju/+bug/1936260))
+- apply resource limits
 
 Before deploying the bundle you will most likely want to create a dedicated model for it:
 
@@ -34,44 +41,75 @@ $ juju add-model cos
 $ juju switch cos
 ```
 
+### Deploy from charmhub
 You can deploy the bundle from charmhub with:
 
 ```shell
 $ juju deploy cos-lite --trust
 ```
 
-or, to deploy the bundle from a local file:
 
+### Deploy using this repo
+To deploy the bundle from a local file:
+
+```shell
+# render bundle with "edge" charms
+$ tox -e render-edge
+
+$ juju deploy ./bundle.yaml --trust
+```
+
+
+### Deploy for testing
+```shell
+tox -e render-edge
+juju deploy ./bundle.yaml --trust \
+  --overlay overlays/tls-overlay.yaml \
+  --overlay overlays/testing-overlay.yaml
+```
+
+
+### Deploy for testing with local charms
 ```shell
 # generate and activate a virtual environment with dependencies
 $ tox -e integration --notest
 $ source .tox/integration/bin/activate
 
-# render bundle with default values
-$ ./render_bundle.py bundle.yaml
+# render bundle, overriding charm paths
+$ ./render_bundle.py bundle.yaml --channel=edge \
+  --traefik=$(pwd)/../path/to/traefik.charm \
+  --prometheus=$(pwd)/../path/to/prometheus.charm \
+  --alertmanager=$(pwd)/../path/to/alertmanager.charm \
+  --grafana=$(pwd)/../path/to/grafana.charm \
+  --loki=$(pwd)/../path/to/loki.charm
+
+# deploy rendered bundle
 $ juju deploy ./bundle.yaml --trust
 ```
 
-Note: for traefik ingress to work, you may first need to enable the `metallb`
-microk8s addon. See the
-[tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s)
-for full details.
 
-The `--trust` option is needed by the charms in the `cos-lite` bundle to be
-able to patch their K8s services to:
-- use the right ports (see this [Juju limitation](https://bugs.launchpad.net/juju/+bug/1936260))
-- apply resource limits
-
+### Overlays
 We also make available some [**overlays**](https://juju.is/docs/sdk/bundle-reference) for convenience:
 
-* the [`offers` overlay](https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the COS Lite charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
-* the [`storage-small` overlays](https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/storage-small-overlay.yaml) provides a setup of the various storages for the COS Lite charms for a small setup.
-  Using an overlay for storage is fundamental for a productive setup, as you cannot change the amount of storage assigned to the various charms after the deployment of COS Lite.
+- [`offers`](overlays/offers-overlay.yaml): exposes as
+  offers the relation endpoints of the COS Lite charms that are likely to be
+  consumed over [cross-model relations].
+- [`storage-small`](overlays/storage-small-overlay.yaml):
+  provides a setup of the various storages for the COS Lite charms for a small
+  setup. Using an overlay for storage is fundamental for a productive setup, as
+  you cannot change the amount of storage assigned to the various charms after
+  the deployment of COS Lite.
+- [`tls`](overlays/tls-overlay.yaml): adds an internal CA to encrypt all
+  inter-workload communications.
+- [`testing`](overlays/testing-overlay.yaml): adds avalanche relation to
+  prometheus and a watchdog alert (always firing) to test prometheus and
+  alertmanager.
 
 In order to use the overlays above, you need to:
 
 1. Download the overlays (or clone the repository)
-2. Pass the `--overlay <path-to-overlay-file-1> --overlay <path-to-overlay-file-2> ...` arguments to the `juju deploy` command
+2. Pass the `--overlay <path-to-overlay-file-1> --overlay <path-to-overlay-file-2> ...`
+   arguments to the `juju deploy` command
 
 For example, to deploy the COS Lite bundle with the offers overlay, you would do the following:
 
@@ -84,6 +122,7 @@ To use COS Lite with machine charms, see
 [cos-proxy](https://charmhub.io/cos-proxy)
 ([source](https://github.com/canonical/cos-proxy-operator)).
 
+
 ## Publishing
 ```shell
 $ tox -e render-edge  # creates bundle.yaml
@@ -91,3 +130,7 @@ $ charmcraft pack
 $ charmcraft upload cos-lite.zip
 $ charmcraft release cos-lite --channel=edge --revision=4
 ```
+
+
+[cross-model relations]: https://juju.is/docs/olm/cross-model-relations
+[tutorial]: https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -14,7 +14,7 @@ applications:
     trust: true
     {%- if traefik is defined and traefik.endswith('.charm') %}
     resources:
-        traefik-image: "jnsgruk/traefik:2.7.0"
+        traefik-image: "ghcr.io/canonical/traefik:2.10.4"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
@@ -24,7 +24,7 @@ applications:
     trust: true
     {%- if alertmanager is defined and alertmanager.endswith('.charm') %}
     resources:
-        alertmanager-image: "ubuntu/prometheus-alertmanager:0.23-22.04_beta"
+        alertmanager-image: "ghcr.io/canonical/alertmanager:0.25.0"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
@@ -34,7 +34,7 @@ applications:
     trust: true
     {%- if prometheus is defined and prometheus.endswith('.charm') %}
     resources:
-      prometheus-image: "ubuntu/prometheus:2.33-22.04_beta"
+      prometheus-image: "ghcr.io/canonical/prometheus:dev"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
@@ -44,8 +44,8 @@ applications:
     trust: true
     {%- if grafana is defined and grafana.endswith('.charm') %}
     resources:
-      grafana-image: "ubuntu/grafana:9.2-22.04_beta"
-      litestream-image: "litestream/litestream:0.4.0-beta.2"
+      grafana-image: "docker.io/ubuntu/grafana:9.2-22.04_beta"
+      litestream-image: "docker.io/litestream/litestream:0.4.0-beta.2"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
@@ -55,7 +55,7 @@ applications:
     trust: true
     {%- if catalogue is defined and catalogue.endswith('.charm') %}
     resources:
-      catalogue-image: "ghcr.io/canonical/catalogue-k8s"
+      catalogue-image: "ghcr.io/canonical/catalogue-k8s-operator:latest"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
@@ -71,7 +71,7 @@ applications:
     trust: true
     {%- if loki is defined and loki.endswith('.charm') %}
     resources:
-      loki-image: "grafana/loki:2.4.1"
+      loki-image: "ghcr.io/canonical/loki:2.7.4"
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -1,7 +1,25 @@
 applications:
   alertmanager:
-    # Ideally we'd want a scale of 2 here, but on a 2cpu github runner it exhausts available CPU.
-    scale: 1
+    scale: 2
+    # Set low resource requests to accommodate small VMs
+    options:
+      cpu: 1m
+      memory: 1Mi
+  prometheus:
+    # Set low resource requests to accommodate small VMs
+    options:
+      cpu: 1m
+      memory: 1Mi
+  grafana:
+    # Set low resource requests to accommodate small VMs
+    options:
+      cpu: 1m
+      memory: 1Mi
+  loki:
+    # Set low resource requests to accommodate small VMs
+    options:
+      cpu: 1m
+      memory: 1Mi
   avalanche:
     charm: avalanche-k8s
     channel: edge

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -1,6 +1,7 @@
 applications:
   alertmanager:
-    scale: 2
+    # Ideally we'd want a scale of 2 here, but on a 2cpu github runner it exhausts available CPU.
+    scale: 1
   avalanche:
     charm: avalanche-k8s
     channel: edge

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -1,4 +1,3 @@
----
 applications:
   alertmanager:
     scale: 2

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -1,0 +1,15 @@
+---
+applications:
+  alertmanager:
+    scale: 2
+  avalanche:
+    charm: avalanche-k8s
+    channel: edge
+    scale: 2
+    trust: true
+    options:
+      metric_count: 10
+      series_count: 2
+
+relations:
+  - [avalanche:metrics-endpoint, prometheus]

--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -12,7 +12,7 @@ applications:
     channel: edge
     scale: 1
     options:
-      ca-common-name: external.demo.ca
+      ca-common-name: external-ca.example.com
 
 relations:
  # This is a more general CA (e.g. root CA) that signs traefik's own CSR.

--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -3,9 +3,21 @@ applications:
     charm: self-signed-certificates
     channel: edge
     scale: 1
+  external-ca:
+    # This charm needs to be replaced with a real CA charm.
+    # Use `juju refresh --switch` to replace via a "crossgrade refresh".
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
 
 relations:
+ # This is a more general CA (e.g. root CA) that signs traefik's own CSR.
+ - [external-ca, traefik:certificates]
+
+  # This is the local CA that signs CSRs from COS charms (excluding traefik).
+  # Traefik is trusting this CA so that it could load balance via TLS.
  - [ca, traefik:receive-ca-cert]
+
  - [ca, alertmanager:certificates]
  - [ca, prometheus:certificates]
  - [ca, grafana:certificates]

--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -1,4 +1,3 @@
----
 applications:
   ca:
     charm: self-signed-certificates

--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -1,0 +1,14 @@
+---
+applications:
+  ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+
+relations:
+ - [ca, traefik:receive-ca-cert]
+ - [ca, alertmanager:certificates]
+ - [ca, prometheus:certificates]
+ - [ca, grafana:certificates]
+ - [ca, loki:certificates]
+ - [ca, catalogue:certificates]

--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -3,12 +3,16 @@ applications:
     charm: self-signed-certificates
     channel: edge
     scale: 1
+    options:
+      ca-common-name: ca.demo.local
   external-ca:
     # This charm needs to be replaced with a real CA charm.
     # Use `juju refresh --switch` to replace via a "crossgrade refresh".
     charm: self-signed-certificates
     channel: edge
     scale: 1
+    options:
+      ca-common-name: external.demo.ca
 
 relations:
  # This is a more general CA (e.g. root CA) that signs traefik's own CSR.

--- a/tests/e2e/test_machine_agent.py
+++ b/tests/e2e/test_machine_agent.py
@@ -160,7 +160,7 @@ async def test_metrics(ops_test):
         f"{k8s_ctl.controller_name}:{k8s_mdl.name}",
         "prometheus/0",
         "curl",
-        f"localhost:9090/api/v1/label/juju_unit/values",
+        "localhost:9090/api/v1/label/juju_unit/values",
     ]
     try:
         result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/tests/e2e/test_machine_agent.py
+++ b/tests/e2e/test_machine_agent.py
@@ -160,7 +160,7 @@ async def test_metrics(ops_test):
         f"{k8s_ctl.controller_name}:{k8s_mdl.name}",
         "prometheus/0",
         "curl",
-        f"localhost:9090/{k8s_mdl.name}-prometheus-0/api/v1/label/juju_unit/values",
+        f"localhost:9090/api/v1/label/juju_unit/values",
     ]
     try:
         result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/tests/e2e/test_machine_agent.py
+++ b/tests/e2e/test_machine_agent.py
@@ -97,11 +97,9 @@ async def test_deploy_machine_charms():
     )
     # Must relate the subordinate before any "wait for idle", because otherwise agent would be in
     # 'unknown' status.
-    await asyncio.gather(
-        lxd_mdl.add_relation(f"{principal_cos_agent.name}:cos-agent", agent.name),
-        lxd_mdl.add_relation(f"{principal_juju_info.name}:juju-info", agent.name),
-        lxd_mdl.block_until(lambda: len(lxd_mdl.applications[agent.name].units) > 0),
-    )
+    await lxd_mdl.add_relation(f"{principal_cos_agent.name}:cos-agent", agent.name)
+    await lxd_mdl.add_relation(f"{principal_juju_info.name}:juju-info", agent.name)
+    await lxd_mdl.block_until(lambda: len(lxd_mdl.applications[agent.name].units) > 0)
 
 
 @pytest.mark.abort_on_fail
@@ -133,12 +131,17 @@ async def test_integration():
 
     # `idle_period` needs to be greater than the scrape interval to make sure metrics ingested.
     await asyncio.gather(
-        lxd_mdl.wait_for_idle(
-            status="active", timeout=7200, idle_period=180, raise_on_error=False
-        ),
-        k8s_mdl.wait_for_idle(
-            status="active", timeout=7200, idle_period=180, raise_on_error=False
-        ),
+        # First, we wait for the critical phase to pass with raise_on_error=False.
+        # (In CI, using github runners, we often see unreproducible hook failures.)
+        lxd_mdl.wait_for_idle(timeout=1800, idle_period=180, raise_on_error=False),
+        k8s_mdl.wait_for_idle(timeout=1800, idle_period=180, raise_on_error=False),
+    )
+
+    await asyncio.gather(
+        # Then we wait for "active", without raise_on_error=False, so the test fails sooner in case
+        # there is a persistent error status.
+        lxd_mdl.wait_for_idle(status="active", timeout=7200, idle_period=180),
+        k8s_mdl.wait_for_idle(status="active", timeout=7200, idle_period=180),
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,16 @@ def get_this_script_dir() -> Path:
     return Path(path)
 
 
+@pytest.fixture(autouse=True, scope="module")
+async def setup_env(ops_test: OpsTest):
+    # Prevent "update-status" from interfering with the test:
+    # - if fired "too quickly", traefik will flip between active/idle and maintenance;
+    # - make sure charm code does not rely on update-status for correct operation.
+    await ops_test.model.set_config(
+        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
+    )
+
+
 def pytest_addoption(parser):
     # not providing the "default" arg to addoption: the bundle template already specifies defaults
     parser.addoption("--traefik", action="store")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -62,7 +62,7 @@ async def get_proxied_url(ops_test: OpsTest, app_name: str, unit_num: Optional[i
 
     logging.debug(f"Endpoints proxied by Traefik/0: {proxied_endpoints}")
 
-    key = f"{app_name}/{unit_num}" if unit_num else app_name
+    key = f"{app_name}/{unit_num}" if unit_num is not None else app_name
     return proxied_endpoints[key]["url"]
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -60,8 +60,10 @@ async def get_proxied_unit_url(ops_test: OpsTest, app_name: str, unit_num: int) 
 
     traefik_address = await get_address(ops_test, "traefik")
     url = urlparse(unit_url)
+    if not (port := url.port):
+        port = 443 if url.scheme == "https" else 80
 
-    final_url = f"{url.scheme}://{traefik_address}:{url.port}{url.path}"
+    final_url = f"{url.scheme}://{traefik_address}:{port}{url.path}"
     logging.debug(f"Routing over traefik using: {final_url}")
 
     return final_url

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -6,23 +6,44 @@
 import asyncio
 import json
 import logging
-import urllib.request
+import ssl
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+from urllib.request import urlopen
 
 import juju
 import juju.utils
 import pytest
+import sh
 from helpers import (
     ModelConfigChange,
     cli_deploy_bundle,
     get_address,
     get_alertmanager_alerts,
     get_alertmanager_groups,
-    get_proxied_unit_url,
+    get_proxied_url,
 )
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 juju_topology_keys = {"juju_model_uuid", "juju_model", "juju_application"}
+
+
+# We have a module-scoped parametrization for TLS enablement, so we need to have appropriate
+# SSL contexts. This dict is in module scope so that it is visible to all test methods.
+# This is needed because the cert's contents is known only after deployment.
+@dataclass
+class CertContext:
+    external_ca: Optional[ssl.SSLContext]
+
+
+context = CertContext(external_ca=None)
+
+# We also need an insecure context to connect to e.g. unit ip addresses directly
+insecure_context = ssl.create_default_context()
+insecure_context.check_hostname = False
+insecure_context.verify_mode = ssl.CERT_NONE
 
 
 @pytest.mark.abort_on_fail
@@ -43,71 +64,95 @@ async def test_build_and_deploy(ops_test: OpsTest, rendered_bundle, tls_enabled)
     await ops_test.model.wait_for_idle(
         status="active", timeout=1000, idle_period=90, raise_on_error=False
     )
-
-    prometheus_0_url = await get_proxied_unit_url(ops_test, app_name="prometheus", unit_num=0)
-
-    logger.info(f"Trying to connect to Prometheus over 'traefik/0': {prometheus_0_url}")
-
-    response = urllib.request.urlopen(prometheus_0_url, data=None, timeout=2.0)
-    assert response.code == 200
+    await ops_test.model.wait_for_idle(status="active", timeout=1000, idle_period=90)
 
 
 @pytest.mark.abort_on_fail
-async def test_alertmanager_is_up(ops_test: OpsTest):
-    # TODO Change this when AM is exposed over the ingress
-    address = await get_address(ops_test, "alertmanager", 0)
-    # With ingress in place, need to use model-app as ingress-per-app subpath
-    url = f"http://{address}:9093/{ops_test.model_name}-alertmanager"
-    logger.info("am public address: %s", url)
+async def test_obtain_external_ca_cert():
+    status = sh.juju("status", "--no-color")
+    if "external-ca/0" in status:
+        # Obtain certificate from external-ca
+        temp_dir = tempfile.mkdtemp()
+        cert_path = temp_dir + "/external_ca.pem"
+        sh.jq(
+            "-r",
+            '."external-ca/0".results."ca-certificate"',
+            _in=sh.juju(*"run external-ca/0 get-ca-certificate --format=json --no-color".split()),
+            _out=cert_path,
+        )
+        ctx = ssl.create_default_context()
+        ctx.load_verify_locations(cert_path)
+        context.external_ca = ctx
 
-    response = urllib.request.urlopen(f"{url}/api/v2/status", data=None, timeout=2.0)
-    assert response.code == 200
-    assert "versionInfo" in json.loads(response.read())
+    # At this point, a non-None value in context.external_ca can be used as an indication for
+    # whether TLS is enabled.
 
 
 @pytest.mark.abort_on_fail
-async def test_prometheus_is_up(ops_test: OpsTest):
-    url = await get_proxied_unit_url(ops_test, "prometheus", 0)
+async def test_web_uis_are_reachable_via_ingress_url():
+    # Create mapping from app name (as it appears in catalogue) to its url
+    # Looks like this:
+    # {
+    #   'Grafana': 'https://grafana-0.grafana-endpoints.test.svc.cluster.local:3000',
+    #   'Prometheus': 'https://prometheus-0.prometheus-endpoints.test.svc.cluster.local:9090',
+    #   'Alertmanager': 'https://alertmanager-0.alertmanager-endpoints.test.svc.cluster.local:9093'
+    # }
+    cat_conf = json.loads(
+        sh.juju("ssh", "--container", "catalogue", "catalogue/0", "cat", "/web/config.json")
+    )
+    apps = {app["name"]: app["url"] for app in cat_conf["apps"]}
 
-    logger.info("Prometheus public address: %s", url)
+    for name, url in apps.items():
+        logger.info("Attempting to reach %s (%s)...", name, url)
+        # We intentionally do not want to use "insecure" here, to make sure TLS is set up correctly
+        response = urlopen(
+            url,
+            data=None,
+            timeout=2.0,
+            context=context.external_ca if url.startswith("https://") else None,
+        )
+        assert response.code == 200
 
-    response = urllib.request.urlopen(f"{url}/-/ready", data=None, timeout=2.0)
-    assert response.code == 200
+
+@pytest.mark.abort_on_fail
+async def test_web_uis_are_reachable_via_unit_ip(ops_test: OpsTest, tls_enabled):
+    """Make sure strip-prefix works as expected so that no path is needed when curling unit ip."""
+    for app_name, port, path in [
+        ("alertmanager", 9093, "/api/v2/status"),
+        ("prometheus", 9090, "/-/ready"),
+    ]:
+        address = await get_address(ops_test, app_name, 0)
+        url = f"{'http' if context.external_ca is None else 'https'}://{address}:{port}{path}"
+        logger.info("Attempting to reach %s (%s)...", app_name, url)
+
+        # We always use "insecure" here because we're connecting via unit ip directly.
+        response = urlopen(url, data=None, timeout=2.0, context=insecure_context)
+        assert response.code == 200
 
 
 @pytest.mark.abort_on_fail
 async def test_prometheus_sees_alertmanager(ops_test: OpsTest):
-    prom_url = await get_proxied_unit_url(ops_test, "prometheus", 0)
+    prom_url = await get_proxied_url(ops_test, "prometheus", 0)
 
-    response = urllib.request.urlopen(f"{prom_url}/api/v1/alertmanagers", data=None, timeout=2.0)
+    response = urlopen(
+        f"{prom_url}/api/v1/alertmanagers", data=None, timeout=2.0, context=insecure_context
+    )
     assert response.code == 200
     # an empty response looks like this:
     # {"status":"success","data":{"activeAlertmanagers":[],"droppedAlertmanagers":[]}}
+    decoded = json.loads(response.read().decode("utf8"))
     # a jsonified activeAlertmanagers looks like this:
     # [{'url': 'http://<ingress:80 or fqdn:9093>/api/v2/alerts'}]
-    assert f"/{ops_test.model_name}-alertmanager/api/v2/alerts" in response.read().decode("utf8")
+    active_alertmanagers = decoded["data"]["activeAlertmanagers"]
+    assert len(active_alertmanagers) == len(ops_test.model.applications["prometheus"].units)
 
-    # TODO Make sure activeAlertmanagers includes our am, and that droppedAlertmanagers is empty.
-    # curl -s http://cluster.local:80/test-prometheus-alerts-32k4-prom-0/api/v1/alertmanagers | jq
-    # {
-    #   "status": "success",
-    #   "data": {
-    #     "activeAlertmanagers": [
-    #       {
-    #         "url": "http://cluster.local:80/test-prometheus-alerts-32k4-am/api/v2/alerts"
-    #       }
-    #     ],
-    #     "droppedAlertmanagers": []
-    #   }
-    # }
-
-    # TODO make sure prom/api/v1/alerts has similar content to am/api/v2/alerts
+    # Make sure droppedAlertmanagers is empty
+    assert not decoded["data"].get("droppedAlertmanagers")
 
 
 async def test_juju_topology_labels_in_alerts(ops_test: OpsTest):
-    alerts = await get_alertmanager_alerts(
-        ops_test, "alertmanager", 0, retries=100, path=f"/{ops_test.model_name}-alertmanager"
-    )
+    """For alert labels to reach alertmanager, labels need to be injected and forwarded to prom."""
+    alerts = await get_alertmanager_alerts(ops_test, "alertmanager", retries=100)
 
     i = -1
     for i, alert in enumerate(alerts):
@@ -123,9 +168,7 @@ async def test_juju_topology_labels_in_alerts(ops_test: OpsTest):
 
 
 async def test_alerts_are_grouped(ops_test: OpsTest):
-    groups = await get_alertmanager_groups(
-        ops_test, "alertmanager", 0, retries=100, path=f"/{ops_test.model_name}-alertmanager"
-    )
+    groups = await get_alertmanager_groups(ops_test, "alertmanager", retries=100)
     i = -1
     for i, group in enumerate(groups):
         # make sure all groups are grouped by juju topology keys
@@ -140,7 +183,9 @@ async def test_alerts_are_fired_from_non_leader_units_too(ops_test: OpsTest):
 
     async def all_alerts_fire():
         alerts = await get_alertmanager_alerts(
-            ops_test, "alertmanager", 0, retries=100, path=f"/{ops_test.model_name}-alertmanager"
+            ops_test,
+            "alertmanager",
+            retries=100,
         )
         alerts = list(
             filter(
@@ -177,9 +222,11 @@ async def test_bundle_charms_can_handle_frequent_update_status(ops_test: OpsTest
 
 async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
     """Prometheus should correctly scrape Loki through its traefik endpoint."""
-    prom_url = await get_proxied_unit_url(ops_test, "prometheus", 0)
+    prom_url = await get_proxied_url(ops_test, "prometheus", 0)
 
-    response = urllib.request.urlopen(f"{prom_url}/api/v1/targets", data=None, timeout=2.0)
+    response = urlopen(
+        f"{prom_url}/api/v1/targets", data=None, timeout=2.0, context=insecure_context
+    )
     assert response.code == 200
     targets = json.loads(response.read())["data"]["activeTargets"]
     targets_summary = [(t["discoveredLabels"]["__metrics_path__"], t["health"]) for t in targets]
@@ -189,7 +236,7 @@ async def test_prometheus_scrapes_loki_through_traefik(ops_test: OpsTest):
 
 async def test_loki_receives_logs_through_traefik(ops_test: OpsTest):
     """Loki should be able to receive logs through its traefik endpoint."""
-    loki_url = await get_proxied_unit_url(ops_test, "loki", 0)
+    loki_url = await get_proxied_url(ops_test, "loki", 0)
 
     await ops_test.model.deploy("zinc-k8s", application_name="zinc", channel="stable", trust=True)
     await ops_test.model.wait_for_idle(status="active")
@@ -197,9 +244,33 @@ async def test_loki_receives_logs_through_traefik(ops_test: OpsTest):
     await ops_test.model.add_relation("loki", "zinc")
     await ops_test.model.wait_for_idle(status="active")
     # Check that logs are coming in
-    response = urllib.request.urlopen(f"{loki_url}/loki/api/v1/series")
+    response = urlopen(f"{loki_url}/loki/api/v1/series", context=insecure_context)
     assert response.code == 200
     series = json.loads(response.read())["data"]
     series_charms = [s["juju_charm"] for s in series]
     assert "zinc-k8s" in series_charms
     logger.info("loki is successfully receiving zinc logs through traefik")
+
+
+@pytest.mark.abort_on_fail
+async def test_remove(ops_test):
+    # WHEN the apps are removed
+    apps = list(ops_test.model.applications.values())
+    logger.info("Removing apps: %s", apps)
+    for app in apps:
+        await app.destroy(destroy_storage=True, force=False, no_wait=False)
+
+    # THEN no app goes into error state and the model is empty
+    # TODO when the app removal Juju bug is fixed, replace the following with a wait_for_idle
+    #  with raise_on_error=True and assert len(ops_test.model.applications) == 0
+
+    # Sometimes it take time to remove an app, and sometimes juju never really finishes
+    # removing. Sleep for a bit and then forcing removal.
+    await asyncio.sleep(30)
+    apps = list(ops_test.model.applications.values())
+    logger.info("Removing apps forcefully: %s", apps)
+    for app in apps:
+        await app.destroy(destroy_storage=True, force=True, no_wait=True)
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications) == 0)
+
+    # Note: Removing all apps is also needed to clean the model for the next parametrization.

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -148,7 +148,7 @@ async def test_prometheus_sees_alertmanager(ops_test: OpsTest):
     # a jsonified activeAlertmanagers looks like this:
     # [{'url': 'http://<ingress:80 or fqdn:9093>/api/v2/alerts'}]
     active_alertmanagers = decoded["data"]["activeAlertmanagers"]
-    assert len(active_alertmanagers) == len(ops_test.model.applications["prometheus"].units)
+    assert len(active_alertmanagers) == len(ops_test.model.applications["alertmanager"].units)
 
     # Make sure droppedAlertmanagers is empty
     assert not decoded["data"].get("droppedAlertmanagers")

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -119,7 +119,7 @@ async def test_web_uis_are_reachable_via_ingress_url(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_web_uis_are_reachable_via_unit_ip(ops_test: OpsTest, tls_enabled):
+async def test_web_uis_are_reachable_via_unit_ip(ops_test: OpsTest):
     """Make sure strip-prefix works as expected so that no path is needed when curling unit ip."""
     for app_name, port, path in [
         ("alertmanager", 9093, "/api/v2/status"),

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -264,10 +264,7 @@ async def test_loki_receives_logs(ops_test: OpsTest):
 
     # Without a sleep, we get an empty response. Need to give promtail some time to stream the logs
     # or for loki to display them.
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(status="active"),
-        asyncio.sleep(120)
-    )
+    await asyncio.gather(ops_test.model.wait_for_idle(status="active"), asyncio.sleep(120))
 
     # Check that logs are coming in
     url = f"{loki_url}/loki/api/v1/series"

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 description = Run integration tests
 deps =
     jinja2
-    juju~=3.0.0
+    juju~=3.2.0
     pytest
     pytest-operator
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     juju~=3.1.0  # must be compatible with the juju version installed by CI
     pytest
     pytest-operator
+    sh
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,11 @@ deps =
 passenv =
     K8S_CONTROLLER
     LXD_CONTROLLER
+allowlist_externals =
+    sh
 commands =
+    sh -c 'if [ -z "$K8S_CONTROLLER" ]; then echo "The K8S_CONTROLLER variable must be set."; exit 1; fi'
+    sh -c 'if [ -z "$LXD_CONTROLLER" ]; then echo "The LXD_CONTROLLER variable must be set."; exit 1; fi'
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/e2e
 
 [testenv:render-{edge,beta,candidate,stable}]

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,6 @@ deps =
     juju~=3.1.0  # must be compatible with the juju version installed by CI
     pytest
     pytest-operator
-    sh
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 description = Run integration tests
 deps =
     jinja2
-    juju~=3.2.0
+    juju~=3.1.0  # must be compatible with the juju version installed by CI
     pytest
     pytest-operator
 commands =
@@ -84,7 +84,7 @@ commands =
 description = Run end-to-end tests
 deps =
     jinja2
-    juju~=3.0.0
+    juju~=3.1.0  # must be compatible with the juju version installed by CI
     pytest
     pytest-operator
 passenv =


### PR DESCRIPTION
This PR adds a TLS overlay.

Fixes #78.

Depends on:
- https://github.com/canonical/traefik-k8s-operator/pull/204
- https://github.com/canonical/catalogue-k8s-operator/issues/31
- https://github.com/canonical/alertmanager-k8s-operator/issues/189
- https://github.com/canonical/prometheus-k8s-operator/issues/511
- https://github.com/canonical/grafana-k8s-operator/pull/257
- https://github.com/canonical/prometheus-k8s-operator/pull/524
- https://github.com/canonical/alertmanager-k8s-operator/pull/191
- https://github.com/canonical/traefik-k8s-operator/pull/245
- https://github.com/canonical/observability-libs/pull/60
- https://github.com/canonical/tls-certificates-interface/pull/74
- https://github.com/canonical/traefik-k8s-operator/pull/249
- https://github.com/canonical/prometheus-k8s-operator/issues/533

## Testing
First, deploy the testing overlay:
```
$ tox -e render-edge
$ juju deploy ./bundle.yaml --trust \
  --overlay overlays/tls-overlay.yaml \
  --overlay overlays/testing-overlay.yaml
```

We do not have the `receive-ca-cert` relation yet in cos charms, so the external ca would need to be copied in manually:
```
juju run external-ca/0 get-ca-certificate --format json | jq -r '."external-ca/0".results."ca-certificate"' > external-ca.crt
openssl x509 -noout -text -in external-ca.crt

echo | openssl s_client -showcerts -servername 10.43.8.206 -connect 10.43.8.206:443 | openssl x509 -text -noout

juju scp --container prometheus external-ca.crt prometheus/0:/usr/local/share/ca-certificates
juju ssh --container prometheus prometheus/0 update-ca-certificates --fresh

juju scp --container grafana external-ca.crt grafana/0:/usr/local/share/ca-certificates
juju ssh --container grafana grafana/0 update-ca-certificates --fresh
```

Then:
1. Attempt to manually `curl` each cos component: `juju show-unit catalogue/0 | grep url`.
2. Make sure all scrape targets are healthy: `curl -k https://10.43.8.206/bndl-prometheus-0/api/v1/targets | jq | grep -E "scrapeUrl|health"`.
3. Make sure the watchdog alert from avalanche is firing:
    - In prometheus: `curl <prometheus>/api/v1/alerts`.
    - In alertmanager: `curl <alertmanager>/api/v2/alerts`.
4. Make sure grafana has all the dashboards.