### PR TITLE
Update matrix.yaml

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -3,7 +3,7 @@ name: Periodic integration matrix tests
 on:
   schedule:
     # every Wednesday at 23:00
-    - cron: '0 23 * * WED'
+    - cron: '0 02 * * WED'
   workflow_dispatch:
 
 
@@ -15,16 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         charm-channel: [ "edge", "beta", "candidate", "stable" ]
-        juju-track: [ "3.1", "3.2" ]
+        juju-track: [ "3.1", "3.2", "4.0" ]
+        microk8s-channel: [ "1.25-strict/stable" ]
         include:
           - juju-track: "3.1"
             juju-channel: "3.1/stable"
             juju-agent-version: "3.1.5"
-            microk8s-channel: "1.25/stable"
           - juju-track: "3.2"
             juju-channel: "3.2/stable"
             juju-agent-version: "3.2.0"
-            microk8s-channel: "1.25-strict/stable"
+          - juju-track: "4.0"
+            juju-channel: "4.0/beta"
+            juju-agent-version: "4.0-beta1"
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the periodic matrix tests:
- Run at 2am instead of 11pm, in an attempt to circumvent the random hook errors due to (maybe) slow runners.
- Fix microk8s channel (always use strict).
- Add juju 4 to the matrix.