### PR TITLE
add relation between grafana and external-ca

### DIFF
--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -18,6 +18,10 @@ relations:
  # This is a more general CA (e.g. root CA) that signs traefik's own CSR.
  - [external-ca, traefik:certificates]
 
+ # We need this relation for Grafana to trust externals URLs provided by traefik.
+ # for instance: Loki and Prometheus endpoints data sources.
+ - [external-ca, grafana:receive-ca-cert]
+
   # This is the local CA that signs CSRs from COS charms (excluding traefik).
   # Traefik is trusting this CA so that it could load balance via TLS.
  - [ca, traefik:receive-ca-cert]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -135,6 +135,31 @@ async def test_web_uis_are_reachable_via_unit_ip(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
+async def test_grafana_sees_prometheus_loki_datasources(ops_test: OpsTest):
+    prom_url = await get_proxied_url(ops_test, "prometheus", 0)
+    prom_url = f"{prom_url}/api/v1/status/config"
+    prom_response = urlopen(
+        prom_url,
+        data=None,
+        timeout=2.0,
+        context=context.external_ca if prom_url.startswith("https://") else None,
+    )
+    prom_response_decoded = json.loads(prom_response.read().decode("utf8"))
+    assert prom_response_decoded["status"] == "success"
+
+    loki_url = await get_proxied_url(ops_test, "loki", 0)
+    loki_url = f"{loki_url}/ready"
+    loki_response = urlopen(
+        loki_url,
+        data=None,
+        timeout=2.0,
+        context=context.external_ca if loki_url.startswith("https://") else None,
+    )
+    loki_response_decoded = loki_response.read().decode("utf8")
+    assert loki_response_decoded.strip() == "ready"
+
+
+@pytest.mark.abort_on_fail
 async def test_prometheus_sees_alertmanager(ops_test: OpsTest):
     prom_url = await get_proxied_url(ops_test, "prometheus", 0)
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR solves: https://github.com/canonical/loki-k8s-operator/issues/344

We add a new relation:

```
Integration provider                Requirer                     Interface              Type     Message
external-ca:send-ca-cert            grafana:receive-ca-cert      certificate_transfer   regular  
``` 


