### PR TITLE
skip `external-ca` as it makes no sense in this case

### DIFF
--- a/overlays/tls-overlay.yaml
+++ b/overlays/tls-overlay.yaml
@@ -5,23 +5,9 @@ applications:
     scale: 1
     options:
       ca-common-name: ca.demo.local
-  external-ca:
-    # This charm needs to be replaced with a real CA charm.
-    # Use `juju refresh --switch` to replace via a "crossgrade refresh".
-    charm: self-signed-certificates
-    channel: edge
-    scale: 1
-    options:
-      ca-common-name: external-ca.example.com
 
 relations:
- # This is a more general CA (e.g. root CA) that signs traefik's own CSR.
- - [external-ca, traefik:certificates]
-
-  # This is the local CA that signs CSRs from COS charms (excluding traefik).
-  # Traefik is trusting this CA so that it could load balance via TLS.
- - [ca, traefik:receive-ca-cert]
-
+ - [ca, traefik:certificates]
  - [ca, alertmanager:certificates]
  - [ca, prometheus:certificates]
  - [ca, grafana:certificates]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We are suggesting that the default TLS deployment behavior should be with separate CAs for traefik and the workloads. this adds nothing

## Solution
<!-- A summary of the solution addressing the above issue -->
remove the `external-ca` application from the overlay

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
-

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
-

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
-