### PR TITLE
Add tox env to produce air-gapped artifacts

### DIFF
--- a/download_bundle.py
+++ b/download_bundle.py
@@ -1,0 +1,10 @@
+import sh
+import yaml
+import sys
+from pathlib import Path
+
+frozen_bundle_path = sys.argv[1]
+
+
+frozen_bundle = yaml.safe_load(Path(frozen_bundle_path).read_text())
+print(frozen_bundle)

--- a/freeze_bundle.py
+++ b/freeze_bundle.py
@@ -122,7 +122,9 @@ def freeze_bundle(bundle: dict, cleanup: bool = True):
         # TODO externalize "base_arch" as an input to the script.
         frozen_app = obtain_revisions_from_charmhub(charm_name, app_channel, "amd64", "20.04")
         app["revision"] = frozen_app[charm_name]["revision"]
-        app["resources"].update(frozen_app[charm_name]["resources"])
+        if "resources" not in app:
+            app["resources"] = {}
+        app["resources"].update(frozen_app[charm_name].get("resources", {}))
 
         if cleanup:
             app.pop("constraints", None)

--- a/freeze_bundle.py
+++ b/freeze_bundle.py
@@ -134,9 +134,11 @@ def freeze_bundle(bundle: dict, cleanup: bool = True):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        raise RuntimeError("Expecting one arg: path to bundle yaml")
+    if len(sys.argv) != 3:
+        raise RuntimeError("Expecting two args: path to bundle.yaml and to the output filename")
 
     bundle_path = sys.argv[1]
+    output_path = sys.argv[2]
     frozen = freeze_bundle(yaml.safe_load(Path(bundle_path).read_text()))
-    print(yaml.safe_dump(frozen))
+    with open(output_path, "w") as f:
+        yaml.dump(frozen, f)

--- a/tox.ini
+++ b/tox.ini
@@ -128,4 +128,4 @@ passenv =
     CREDS_FILE
     CHARMHUB_TOKEN
 commands =
-    python {toxinidir}/freeze_bundle.py {toxinidir}/bundle.yaml
+    python {toxinidir}/freeze_bundle.py {toxinidir}/bundle.yaml {toxinidir}/bundle.frozen

--- a/tox.ini
+++ b/tox.ini
@@ -124,8 +124,10 @@ commands =
 description = Freeze bundle
 deps =
     pyyaml
+    sh
 passenv =
     CREDS_FILE
     CHARMHUB_TOKEN
 commands =
     python {toxinidir}/freeze_bundle.py {toxinidir}/bundle.yaml {toxinidir}/bundle.frozen
+    python {toxinidir}/download_bundle.py {toxinidir}/bundle.frozen

--- a/tox.ini
+++ b/tox.ini
@@ -122,5 +122,10 @@ commands =
 
 [testenv:freeze]
 description = Freeze bundle
+deps =
+    pyyaml
+passenv =
+    CREDS_FILE
+    CHARMHUB_TOKEN
 commands =
     python {toxinidir}/freeze_bundle.py {toxinidir}/bundle.yaml

--- a/tox.ini
+++ b/tox.ini
@@ -119,3 +119,8 @@ deps =
     scipy
 commands =
     python {toxinidir}/tests/load/gcp/plot.py
+
+[testenv:freeze]
+description = Freeze bundle
+commands =
+    python {toxinidir}/freeze_bundle.py {toxinidir}/bundle.yaml


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
```bash
tox -e render-stable

dbus-run-session -- bash -c "echo password | gnome-keyring-daemon --unlock; charmcraft login --export charmhub-creds.dat"
export CREDS_FILE="$PWD/charmhub-creds.dat"
tox -e freeze  # creates bundle.frozen
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

