### PR TITLE
Add cloud-init script for a 3-node microk8s ha cluster

### DIFF
--- a/overlays/three-nodes-overlay.yaml
+++ b/overlays/three-nodes-overlay.yaml
@@ -1,0 +1,13 @@
+applications:
+  alertmanager:
+    scale: 3
+    constraints: tags=anti-pod.app.kubernetes.io/name=alertmanager,anti-pod.topology-key=kubernetes.io/hostname
+  prometheus:
+    scale: 3
+    constraints: tags=anti-pod.app.kubernetes.io/name=prometheus,anti-pod.topology-key=kubernetes.io/hostname
+  grafana:
+    scale: 3
+    constraints: tags=anti-pod.app.kubernetes.io/name=grafana,anti-pod.topology-key=kubernetes.io/hostname
+  loki:
+    scale: 3
+    constraints: tags=anti-pod.app.kubernetes.io/name=loki,anti-pod.topology-key=kubernetes.io/hostname

--- a/render_bundle.py
+++ b/render_bundle.py
@@ -89,7 +89,10 @@ def render_bundle(template: Path, output: Path, variables: Optional[Dict[str, st
 
     # print(jinja_template.render(**variables))
     with open(output, "wt") as o:
-        jinja_template.stream(**variables).dump(o)
+        # Type-ignore because pyright complains:
+        # Argument 1 to "dump" of "TemplateStream" has
+        # incompatible type "TextIOWrapper"; expected "Union[str, IO[bytes]]"
+        jinja_template.stream(**variables).dump(o)  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,51 @@
+# Manual tests
+
+## 3-node cluster in a multipass VM (nested virtualization)
+The [`microk8s-ha.yaml`](microk8s-ha.yaml) file contains a cloud-init script
+for an "all in one" VM. When launched the VM will have three nested VMs called
+"node-1", "node-2" and "node-3".
+
+```mermaid
+graph LR
+
+subgraph microk8s-ha multipass VM
+
+subgraph node-0 multipass VM
+microk8s_0[microk8s]
+end
+
+subgraph node-1 multipass VM
+microk8s_1[microk8s]
+end
+
+subgraph node-2 multipass VM
+microk8s_2[microk8s]
+end
+
+juju
+
+end
+```
+
+Launch the VM with:
+```bash
+multipass launch 22.04 --cloud-init microk8s-ha.yaml \
+  --timeout 1800 \
+  --name three-node \
+  --memory 16G \
+  --cpus 14 \
+  --disk 100G
+```
+
+Then shell into the vm, get the `three-nodes-overlay.yaml` file and run:
+```bash
+juju deploy --trust cos-lite --overlay ./three-nodes-overlay.yaml
+```
+
+From within the "outer VM" you can `multipass exec` into the node VMs:
+```bash
+multipass exec node-1 microk8s.kubectl -n welcome-k8s get pods -A
+```
+
+Note that with Juju <3.3.5,<3.4.4, you would need to manually patch the
+statefulsets due to a [bug](https://bugs.launchpad.net/juju/+bug/2062934).

--- a/tests/manual/microk8s-ha.yaml
+++ b/tests/manual/microk8s-ha.yaml
@@ -1,0 +1,168 @@
+# A 3-node microk8s cluster for juju
+#
+# For general purpose initial use, 4cpu4gb with 40GB disk space per node is recommended, so for the
+# host (or outer vm) we'd need 14cpu16gb.
+#
+# multipass launch 22.04 --cloud-init microk8s-ha.yaml \
+#  --timeout 1800 \
+#  --name three-node \
+#  --memory 16G \
+#  --cpus 14 \
+#  --disk 100G
+#
+# This cloud-config creates a 3-node microk8s ha cluster for juju (e.g. in a nested multipass VM).
+# A microk8s controller and an empty model are created as part of the cloud-init script,
+# so you can `juju deploy` right away.
+# Unlike "charm-dev", this blueprint does not install development tools.
+#
+# References:
+# - https://discuss.kubernetes.io/t/microk8s-in-lxd/11520
+
+package_update: true
+
+packages:
+- jq
+- kitty-terminfo
+
+snap:
+  commands:
+  - snap install lxd --channel=5.21/stable
+  - snap install juju --channel=3.4/stable
+  - snap install multipass --channel=latest/stable
+  - snap refresh
+
+write_files:
+- path: "/run/microk8s-cloud-init.yaml"
+  permissions: "0666"
+  content: |
+    #cloud-config
+    package_update: true
+
+    packages:
+    - jq
+    - kitty-terminfo
+
+    snap:
+      commands:
+      - snap install microk8s --channel=1.29-strict/stable
+      - snap alias microk8s.kubectl kubectl
+      - snap alias microk8s.kubectl k
+      - snap refresh
+
+    runcmd:
+    - |
+      # disable swap
+      sysctl -w vm.swappiness=0
+      echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
+      swapoff -a
+
+      # Disable IPv6
+      echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
+      sysctl -p
+
+      # disable unnecessary services
+      systemctl disable man-db.timer man-db.service --now
+      systemctl disable apport.service apport-autoreport.service  --now
+      systemctl disable apt-daily.service apt-daily.timer --now
+      systemctl disable apt-daily-upgrade.service apt-daily-upgrade.timer --now
+      systemctl disable unattended-upgrades.service --now
+      systemctl disable motd-news.service motd-news.timer --now
+      systemctl disable bluetooth.target --now
+      systemctl disable ua-timer.timer ua-timer.service --now
+      systemctl disable systemd-tmpfiles-clean.timer --now
+
+    - |
+      set -eux
+
+      # Setup microk8s
+      microk8s status --wait-ready
+
+      # The dns addon will restart the api server so you may see a blip in the availability
+      microk8s.enable dns
+      microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
+
+      microk8s.enable rbac
+      microk8s.enable hostpath-storage
+      microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
+
+      # MetalLB
+      IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+      microk8s enable metallb:$IPADDR-$IPADDR
+      microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
+
+      usermod -a -G snap_microk8s ubuntu
+
+runcmd:
+- DEBIAN_FRONTEND=noninteractive apt-get remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
+- DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+- DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
+
+- |
+  # disable swap
+  sysctl -w vm.swappiness=0
+  echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
+  swapoff -a
+
+- |
+  # disable unnecessary services
+  systemctl disable man-db.timer man-db.service --now
+  systemctl disable apport.service apport-autoreport.service  --now
+  systemctl disable apt-daily.service apt-daily.timer --now
+  systemctl disable apt-daily-upgrade.service apt-daily-upgrade.timer --now
+  systemctl disable unattended-upgrades.service --now
+  systemctl disable motd-news.service motd-news.timer --now
+  systemctl disable bluetooth.target --now
+  systemctl disable ua-timer.timer ua-timer.service --now
+  systemctl disable systemd-tmpfiles-clean.timer --now
+
+  # Disable IPv6
+  echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
+  echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
+  echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
+  sysctl -p
+
+- |
+  # Set up cluster
+  # Strictly confined snap cannot see `/run`.
+  cp /run/microk8s-cloud-init.yaml ~ubuntu/
+  sudo -u ubuntu multipass launch 22.04 --name node-0 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass exec node-0 -- cloud-init status --wait
+  sudo -u ubuntu multipass exec node-0 -- microk8s config > ~ubuntu/node-0.kube.conf
+  chown ubuntu:ubuntu ~ubuntu/node-0.kube.conf
+
+  sudo -u ubuntu multipass launch 22.04 --name node-1 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass exec node-1 -- cloud-init status --wait
+  sudo -u ubuntu multipass exec node-1 -- microk8s config > ~ubuntu/node-1.kube.conf
+  chown ubuntu:ubuntu ~ubuntu/node-1.kube.conf
+
+  sudo -u ubuntu multipass launch 22.04 --name node-2 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass exec node-2 -- cloud-init status --wait
+  sudo -u ubuntu multipass exec node-2 -- microk8s config > ~ubuntu/node-2.kube.conf
+  chown ubuntu:ubuntu ~ubuntu/node-2.kube.conf
+
+  # https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+  TOKEN=$(tr -dc a-f0-9 </dev/urandom | head -c 32)
+  URL=$(sudo -u ubuntu multipass exec node-0 -- sudo microk8s add-node --token $TOKEN --format json | jq -r '.urls[0]')
+  sudo -u ubuntu multipass exec node-1 -- sudo microk8s join $URL
+
+  TOKEN=$(tr -dc a-f0-9 </dev/urandom | head -c 32)
+  URL=$(sudo -u ubuntu multipass exec node-0 -- sudo microk8s add-node --token $TOKEN --format json | jq -r '.urls[0]')
+  sudo -u ubuntu multipass exec node-2 -- sudo microk8s join $URL
+
+  # Make sure everything is ok
+  sudo -u ubuntu multipass exec node-0 microk8s kubectl get node
+
+- |
+  # Setup juju
+  sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+  # Gotta sleep a bit before add-k8s, otherwise:
+  # ERROR making juju admin credentials in cluster: ensuring cluster role "juju-credential-fabcd43f" in namespace "kube-system": Get "https://10.25.94.86:16443/apis/rbac.authorization.k8s.io/v1/clusterroles/juju-credential-fabcd43f": net/http: TLS handshake timeout
+  sleep 30
+  sudo -u ubuntu sh -c 'KUBECONFIG="/home/ubuntu/node-0.kube.conf" juju add-k8s microk8s-cluster --client'
+  sudo -u ubuntu juju bootstrap microk8s-cluster k8s
+  sudo -u ubuntu juju add-model welcome-k8s
+
+final_message: "The system is finally up, after $UPTIME seconds"


### PR DESCRIPTION
## Issue
We need a reference deployment for testing a clustered COS.


## Solution
This PR adds:
- [x] a cloud-init script for a 3-node microk8s ha cluster for juju (nested multipass).
- [x] an overlay with anti-affinity constraints.

```mermaid
graph LR

subgraph microk8s-ha multipass VM

subgraph node-0 multipass VM
microk8s_0[microk8s]
end

subgraph node-1 multipass VM
microk8s_1[microk8s]
end

subgraph node-2 multipass VM
microk8s_2[microk8s]
end

juju

end
```

As of now, I am unaware of any readily deployable environment with such a setup. We (the o11y team) intend to use this as a baseline for a reference deployment of COS Lite.

A microk8s controller and an empty juju model are created as part of the cloud-init script so you can `juju deploy` right away. [Example](https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13).

Manually tested restarting the inner and outer VMs.

References:
- https://discuss.kubernetes.io/t/microk8s-in-lxd/11520

## Context
- This PR supersedes:
  - https://github.com/canonical/multipass-blueprints/pull/47
  - https://github.com/Abuelodelanada/charm-dev-utils/pull/9
- Separately from this PR, we need to add:
  - instructions on how to use ceph instead of hostpath-storage

## Testing Instructions
```bash
multipass launch 22.04 --cloud-init microk8s-ha.yaml \
  --timeout 1800 \
  --name three-node \
  --memory 16G \
  --cpus 14 \
  --disk 100G
```
Then shell into the vm, paste the overlay and:
```bash
juju deploy --trust cos-lite --overlay ./three-node.yaml
```

Each pod should be on a different node:
```
$ multipass exec node-1 -- microk8s.kubectl -n welcome-k8s get pods -o wide --sort-by=.spec.nodeName
NAME                             READY   STATUS    RESTARTS   AGE    IP            NODE     NOMINATED NODE   READINESS GATES
prometheus-2                     2/2     Running   0          42m    10.1.39.204   node-0   <none>           <none>
loki-0                           2/2     Running   0          33m    10.1.39.209   node-0   <none>           <none>
traefik-0                        2/2     Running   0          83m    10.1.39.198   node-0   <none>           <none>
alertmanager-2                   2/2     Running   0          43m    10.1.39.203   node-0   <none>           <none>
grafana-0                        3/3     Running   0          37m    10.1.39.206   node-0   <none>           <none>
loki-2                           2/2     Running   0          43m    10.1.84.137   node-1   <none>           <none>
modeloperator-547dc677f5-9wghn   1/1     Running   0          165m   10.1.84.130   node-1   <none>           <none>
alertmanager-0                   2/2     Running   0          38m    10.1.84.140   node-1   <none>           <none>
grafana-2                        3/3     Running   0          43m    10.1.84.138   node-1   <none>           <none>
prometheus-0                     2/2     Running   0          34m    10.1.84.142   node-1   <none>           <none>
catalogue-0                      2/2     Running   0          84m    10.1.84.131   node-1   <none>           <none>
alertmanager-1                   2/2     Running   0          41m    10.1.247.6    node-2   <none>           <none>
grafana-1                        3/3     Running   0          41m    10.1.247.8    node-2   <none>           <none>
prometheus-1                     2/2     Running   0          40m    10.1.247.10   node-2   <none>           <none>
loki-1                           2/2     Running   0          39m    10.1.247.13   node-2   <none>           <none>
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
