### PR TITLE
feat: expose loki retention-period config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ $ ./render_bundle.py bundle.yaml --channel=edge \
   --prometheus=$(pwd)/../path/to/prometheus.charm \
   --alertmanager=$(pwd)/../path/to/alertmanager.charm \
   --grafana=$(pwd)/../path/to/grafana.charm \
-  --loki=$(pwd)/../path/to/loki.charm
+  --loki=$(pwd)/../path/to/loki.charm \
+  --loki_retention_period=30
 
 # deploy rendered bundle
 $ juju deploy ./bundle.yaml --trust

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -75,6 +75,8 @@ applications:
     {%- else %}
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
+    options:
+      retention-period: {{ loki_retention_period|default(0) }}
 
 relations:
 - [traefik:ingress-per-unit, prometheus:ingress]

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -20,6 +20,7 @@ applications:
     options:
       cpu: 1m
       memory: 1Mi
+      retention-period: 30 # retention period in number of days
   avalanche:
     charm: avalanche-k8s
     channel: edge

--- a/tox.ini
+++ b/tox.ini
@@ -105,10 +105,10 @@ deps =
 allowlist_externals =
     /usr/bin/env
 commands =
-    edge: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=edge
-    beta: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=beta
-    candidate: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=candidate
-    stable: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=stable
+    edge: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --loki_retention_period=30 --channel=edge
+    beta: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --loki_retention_period=30 --channel=beta
+    candidate: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --loki_retention_period=30 --channel=candidate
+    stable: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --loki_retention_period=30 --channel=stable
 
 [testenv:datasheet]
 description = Plot load test results

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -41,9 +41,9 @@ deps =
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     # Need to override ruff's default exclude patterns, which include '.tpl.py'
-    ruff --exclude .terraform {[vars]tst_path}/load
+    ruff check --exclude .terraform {[vars]tst_path}/load
     black --extend-exclude '/\.terraform/' --check --diff {[vars]all_path}
 
 [testenv:static-{bundle,integration,load}]


### PR DESCRIPTION
## Issue
Currently the `cos-lite-bundle` does not offer any way to configure Loki retention.

## Solution
Charm `loki-k8s-operator` offers since few months ago a new config key named `retention-period` that allows to configure Loki to the specified retention and activates the compactor in Loki. It'd be great if we can expose this setting in the `cos-lite-bundle`.


## Context
When deploying the bundle, an operator typically wants some retention policy for the logs, and as the bundle is currently there is no way to configure any.


## Testing Instructions
Render the bundle with `loki_retention_period=30`.

Observe Loki configuration to contain these two settings:
```
retention_enabled: True
```
and in the `limits_config` there should be
```
retention_period: 30d
```


## Adjusted `ruff` syntax
It was not in the scope of this PR but for the linter in the CI to work I fixed the `ruff` syntax, which now expects the keyword `check` after `ruff` and before the path. Let me know if you prefer I do that in a separate PR.