### PR TITLE
Fix Lint errors and Warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,14 @@ exclude = "\\.tpl\\.py$"
 [tool.ruff]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info", "*.tpl.py", ".terraform*"]
-select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+lint.select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["E501", "D107", "RET504"]
+lint.ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 # Static analysis tools configuration

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -41,9 +41,9 @@ deps =
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     # Need to override ruff's default exclude patterns, which include '.tpl.py'
-    ruff --exclude .terraform {[vars]tst_path}/load
+    ruff check --exclude .terraform {[vars]tst_path}/load
     black --extend-exclude '/\.terraform/' --check --diff {[vars]all_path}
 
 [testenv:static-{bundle,integration,load}]


### PR DESCRIPTION
Fix:
* Lint warnings
* Update to "ruff check" syntax ([example](https://github.com/canonical/cos-lite-bundle/actions/runs/10477442631/job/29018544646#step:5:143))